### PR TITLE
Added comment that time/zone will be escaped to time\/zone 

### DIFF
--- a/installation.adoc
+++ b/installation.adoc
@@ -142,6 +142,9 @@ NOTE: If kbd:[e] doesn't work, UEFI is not available.  It may be possible to ena
 
    locale=en_US.UTF8 netcfg/disable_dhcp=true time/zone=UTC
 
+NOTE: If typing *time/zone=UTC* it may automatically be changed (escaped) to
+      *time\/zone=UTC* (extra backslash). This is fine.
+
 . Press:
     * BIOS: kbd:[Enter]
     * UEFI: kbd:[F10] 


### PR DESCRIPTION
When I ran through the installation, I was briefly worried/confused by the fact that when I wrote "time/zone=UTC" on the vmlinuz line, it automatically changed to the escaped version "time\/zone=UTC". I think it is worth noting this to avoid others being worried about this. This commit is a suggested addition NOTE about this.