### PR TITLE
Allowing for possibility of LVM on top of RAID

### DIFF
--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -150,19 +150,25 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
 					if [ $VERBOSE -ne 0 ]; then
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+						[ $DRY_RUN -eq 0 ] && lvremove -v -f $VG/$lv
 					else
 						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
 					fi
 				done
 				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+					[ $DRY_RUN -eq 0 ] && vgremove -v -f $VG
 				else
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null
+					[ $DRY_RUN -eq 0 ] && vgremove -f $VG > /dev/null
+				fi
+			else
+				if [ $VERBOSE -ne 0 ]; then
+					[ $DRY_RUN -eq 0 ] && vgreduce -v $VG /dev/$taid
+				else
+					[ $DRY_RUN -eq 0 ] && vgreduce $VG /dev/$raid > /dev/null
 				fi
 			fi
 			if [ $VERBOSE -ne 0 ]; then
-				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid
+				[ $DRY_RUN -eq 0 ] && pvremove -v -ff -y /dev/$raid
 			else
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid > /dev/null
 			fi
@@ -174,7 +180,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid
 			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
 		else
-			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid > /dev/null
+			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid > /dev/null 2>&1
 			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part >/dev/null 2>&1
 		fi
 	else
@@ -219,19 +225,25 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
 					if [ $VERBOSE -ne 0 ]; then
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+						[ $DRY_RUN -eq 0 ] && lvremove -v -f $VG/$lv
 					else
 						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
 					fi
 				done
 				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+					[ $DRY_RUN -eq 0 ] && vgremove -v -f $VG
 				else
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null
+					[ $DRY_RUN -eq 0 ] && vgremove -f $VG > /dev/null
+				fi
+			else
+				if [ $VERBOSE -ne 0 ]; then
+					[ $DRY_RUN -eq 0 ] && vgreduce -v $VG /dev/$part
+				else
+					[ $DRY_RUN -eq 0 ] && vgreduce $VG /dev/$part > /dev/null
 				fi
 			fi
 			if [ $VERBOSE -ne 0 ]; then
-				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part
+				[ $DRY_RUN -eq 0 ] && pvremove -v -ff -y /dev/$part
 			else
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part > /dev/null
 			fi

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -106,6 +106,8 @@ if [ $VERBOSE -eq 0 ]; then
 	done
 fi
 
+VG0=$(pvs --noheadings -o vg_name /dev/md0 | tr -d " ")
+
 for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 	partnum=$(echo $part | sed -e "s/$devname//")
 	[ $VERBOSE -ne 0 ] && sgdisk -i$partnum $disk | head -n 1
@@ -129,7 +131,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			VG=$(pvs --noheadings -o vg_name /dev/$raid | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$raid | tr -d " " | sort -u)
 			if [ $VERBOSE -ne 0 ]; then
-				echo "In use as a LVM physical volume:"
+				echo "In use as LVM physical volume:"
 				pvdisplay /dev/$raid
 				echo -n "Which contains LV(s):"
 				for lv in $LVS; do
@@ -138,10 +140,13 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				echo -n "Delete RAID+LVM contents (Control-C aborts)? "
 				read $ans
 			fi
-			for lv in $LVS; do
-				lvremove -f $VG/$lv
-			done
-			vgreduce -f $VG /dev/$raid
+			if [ $VG -ne $VG0 ]; then
+				# Only unwind LVM if _not_ our primary VG!!!
+				for lv in $LVS; do
+					lvremove -f $VG/$lv
+				done
+				vgremove -ff $VG
+			fi
 			pvremove -ff -y /dev/$raid
 		elif [ $VERBOSE -ne 0 ]; then
 			echo -n "Delete RAID contents (Control-C aborts)? "
@@ -176,7 +181,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			VG=$(pvs --noheadings -o vg_name /dev/$part | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$part | tr -d " " | sort -u)
 			if [ $VERBOSE -ne 0 ]; then
-				echo "Detected raw LVM physical volume:"
+				echo "Detected LVM physical volume:"
 				pvdisplay /dev/$part
 				echo -n "Which contains LV(s):"
 				for lv in $LVS; do
@@ -185,10 +190,13 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				echo -n "Delete LVM contents (Control-C aborts)? "
 				read $ans
 			fi
-			for lv in $LVS; do
-				lvremove -f $VG/$lv
-			done
-			vgreduce -f $VG /dev/$part
+			if [ $VG -ne $VG0 ]; then
+				# Only unwind LVM if _not_ our primary VG!!!
+				for lv in $LVS; do
+					lvremove -f $VG/$lv
+				done
+				vgremove -ff $VG
+			fi
 			pvremove -ff -y /dev/$part
 		elif [ $VERBOSE -ne 0 ]; then
 			echo "Detected unrecognised partition: /dev/$part"

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -112,8 +112,6 @@ if [ $VERBOSE -eq 0 ]; then
 	done
 fi
 
-VG0=$(pvs --noheadings -o vg_name /dev/md0 | tr -d " ")
-
 for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 	partnum=$(echo $part | sed -e "s/$devname//")
 	[ $VERBOSE -ne 0 ] && sgdisk -i$partnum $disk | head -n 1
@@ -135,6 +133,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 		fi
 		if pvdisplay /dev/$raid 2>/dev/null | grep -q "/dev/$raid" ; then
 			VG=$(pvs --noheadings -o vg_name /dev/$raid | tr -d " ")
+			VG_UUID=$(pvs --noheadings -o vg_uuid /dev/$raid | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$raid | tr -d " " | sort -u)
 			if [ $VERBOSE -ne 0 ]; then
 				echo "In use as LVM physical volume:"
@@ -145,31 +144,12 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				done; echo
 				echo -n "Delete RAID+LVM contents (Control-C aborts)? "
 				read $ans
-			fi
-			if [ $VG != $VG0 ]; then
-				# Only unwind LVM if _not_ our primary VG!!!
-				for lv in $LVS; do
-					if [ $VERBOSE -ne 0 ]; then
-						[ $DRY_RUN -eq 0 ] && lvremove -v -f $VG/$lv
-					else
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
-					fi
-				done
-				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgremove -v -f $VG
-				else
-					[ $DRY_RUN -eq 0 ] && vgremove -f $VG > /dev/null
-				fi
-			else
-				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgreduce -v $VG /dev/$taid
-				else
-					[ $DRY_RUN -eq 0 ] && vgreduce $VG /dev/$raid > /dev/null
-				fi
-			fi
-			if [ $VERBOSE -ne 0 ]; then
+				[ $DRY_RUN -eq 0 ] && lvremove -v -f -S vg_uuid=$VG_UUID
+				[ $DRY_RUN -eq 0 ] && vgremove -v -f -S vg_uuid=$VG_UUID
 				[ $DRY_RUN -eq 0 ] && pvremove -v -ff -y /dev/$raid
 			else
+				[ $DRY_RUN -eq 0 ] && lvremove -f -S vg_uuid=$VG_UUID > /dev/null
+				[ $DRY_RUN -eq 0 ] && vgremove -f -S vg_uuid=$VG_UUID > /dev/null
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid > /dev/null
 			fi
 		elif [ $VERBOSE -ne 0 ]; then
@@ -210,6 +190,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			fi
 		elif pvdisplay /dev/$part 2>/dev/null | grep -q "/dev/$part" ; then
 			VG=$(pvs --noheadings -o vg_name /dev/$part | tr -d " ")
+			VG_UUID=$(pvs --noheadings -o vg_uuid /dev/$part | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$part | tr -d " " | sort -u)
 			if [ $VERBOSE -ne 0 ]; then
 				echo "Detected LVM physical volume:"
@@ -220,31 +201,12 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				done; echo
 				echo -n "Delete LVM contents (Control-C aborts)? "
 				read $ans
-			fi
-			if [ $VG != $VG0 ]; then
-				# Only unwind LVM if _not_ our primary VG!!!
-				for lv in $LVS; do
-					if [ $VERBOSE -ne 0 ]; then
-						[ $DRY_RUN -eq 0 ] && lvremove -v -f $VG/$lv
-					else
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
-					fi
-				done
-				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgremove -v -f $VG
-				else
-					[ $DRY_RUN -eq 0 ] && vgremove -f $VG > /dev/null
-				fi
-			else
-				if [ $VERBOSE -ne 0 ]; then
-					[ $DRY_RUN -eq 0 ] && vgreduce -v $VG /dev/$part
-				else
-					[ $DRY_RUN -eq 0 ] && vgreduce $VG /dev/$part > /dev/null
-				fi
-			fi
-			if [ $VERBOSE -ne 0 ]; then
+				[ $DRY_RUN -eq 0 ] && lvremove -v -f -S vg_uuid=$VG_UUID
+				[ $DRY_RUN -eq 0 ] && vgremove -v -f -S vg_uuid=$VG_UUID 
 				[ $DRY_RUN -eq 0 ] && pvremove -v -ff -y /dev/$part
 			else
+				[ $DRY_RUN -eq 0 ] && lvremove -f -S vg_uuid=$VG_UUID > /dev/null
+				[ $DRY_RUN -eq 0 ] && vgremove -f -S vg_uuid=$VG_UUID > /dev/null
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part > /dev/null
 			fi
 		elif [ $VERBOSE -ne 0 ]; then

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -123,7 +123,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
         	echo "ERROR: \"Secondary\" disk $disk is currently part of RAID /dev/md0!!"
 		exit 1
 	elif [ ! -z $raid ]; then
-		if grep ^"$raid" /proc/mdstat | grep " sda" > /dev/null; then
+		if grep ^"$raid" /proc/mdstat | grep -q " sda"; then
         		echo -n "ERROR: \"Primary\" disk /dev/sda is in a common RAID array: "
 			mdadm --detail --scan /dev/$raid
 			exit 1
@@ -152,19 +152,19 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 					if [ $VERBOSE -ne 0 ]; then
 						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
 					else
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null 2>&1
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
 					fi
 				done
 				if [ $VERBOSE -ne 0 ]; then
 					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
 				else
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null 2>&1
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null
 				fi
 			fi
 			if [ $VERBOSE -ne 0 ]; then
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid
 			else
-				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid > /dev/null 2>&1
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid > /dev/null
 			fi
 		elif [ $VERBOSE -ne 0 ]; then
 			echo -n "Delete RAID contents (Control-C aborts)? "
@@ -174,7 +174,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid
 			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
 		else
-			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid > /dev/null 2>&1
+			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid > /dev/null
 			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part >/dev/null 2>&1
 		fi
 	else
@@ -221,19 +221,19 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 					if [ $VERBOSE -ne 0 ]; then
 						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
 					else
-						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null 2>&1
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null
 					fi
 				done
 				if [ $VERBOSE -ne 0 ]; then
 					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
 				else
-					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null 2>&1
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null
 				fi
 			fi
 			if [ $VERBOSE -ne 0 ]; then
 				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part
 			else
-				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part > /dev/null 2>&1
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part > /dev/null
 			fi
 		elif [ $VERBOSE -ne 0 ]; then
 			echo "Detected unrecognised partition: /dev/$part"
@@ -246,7 +246,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 		[ $DRY_RUN -eq 0 ] && wipefs -a /dev/$part
 		echo -e "done.\n"
 	else
-		[ $DRY_RUN -eq 0 ] && wipefs -aq /dev/$part > /dev/null 2>&1
+		[ $DRY_RUN -eq 0 ] && wipefs -aq /dev/$part > /dev/null
 	fi
 done
 if [ $VERBOSE -ne 0 ]; then
@@ -260,11 +260,11 @@ if [ $VERBOSE -ne 0 ]; then
 	[ $DRY_RUN -eq 0 ] && wipefs -a $disk
 else
 	if $(partprobe -ds $disk | grep -q msdos); then
-		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk > /dev/null 2>&1
+		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk > /dev/null
 	else
-		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk > /dev/null 2>&1
+		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk > /dev/null
 	fi
-	[ $DRY_RUN -eq 0 ] && wipefs -aq $disk > /dev/null 2>&1
+	[ $DRY_RUN -eq 0 ] && wipefs -aq $disk > /dev/null
 fi
 if [ $DRY_RUN -eq 0 ]; then
 	echo -e "\n\"Secondary\" disk $disk is hopefully now blank!"

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -124,10 +124,29 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 		if [ $VERBOSE -ne 0 ]; then
 			echo -n "Detected /dev/$part in \"foreign\" RAID array: "
 			mdadm --detail /dev/$raid
+		fi
+		if pvdisplay /dev/$raid 2>/dev/null | grep -q "/dev/$raid" ; then
+			VG=$(pvs --noheadings -o vg_name /dev/$raid | tr -d " ")
+			LVS=$(pvs --noheadings -o lv_name /dev/$raid | tr -d " " | sort -u)
+			if [ $VERBOSE -ne 0 ]; then
+				echo "In use as a LVM physical volume:"
+				pvdisplay /dev/$raid
+				echo -n "Which contains LV(s):"
+				for lv in $LVS; do
+					echo -n " $VG/$lv"
+				done; echo
+				echo -n "Delete RAID+LVM contents (Control-C aborts)? "
+				read $ans
+			fi
+			for lv in $LVS; do
+				lvremove -f $VG/$lv
+			done
+			vgreduce -f $VG /dev/$raid
+			pvremove -ff -y /dev/$raid
+		elif [ $VERBOSE -ne 0 ]; then
 			echo -n "Delete RAID contents (Control-C aborts)? "
 			read $ans
 		fi
-		pvremove -ff -y /dev/$raid 2>/dev/null
 		mdadm -S /dev/$raid
 		mdadm --zero-superblock --force /dev/$part 2>/dev/null
 	else
@@ -202,6 +221,6 @@ else
 	fi
 	wipefs -aq $disk > /dev/null
 fi
-echo -e "\n\"Secondary\" disk $disk is now blank!"
+echo -e "\n\"Secondary\" disk $disk is hopefully now blank!"
 
 exit 0

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -24,11 +24,15 @@
 usage() { echo "Usage: $0 [-A][-h]"; echo -e "  where\t-A\tAllow \"Secondary\" disk to be loaded at start"; echo -e "  \t-h\tdisplay this help and exit"; }
 
 ACCEPT_LOAD=0
+DRY_RUN=0
 VERBOSE=0
-while getopts "Avh" arg; do
+while getopts "Anvh" arg; do
 	case $arg in
 		A)
 			ACCEPT_LOAD=1
+			;;
+		n)
+			DRY_RUN=1
 			;;
 		v)
 			VERBOSE=1
@@ -39,6 +43,8 @@ while getopts "Avh" arg; do
 			;;
 	esac
 done
+
+[ $DRY_RUN -eq 0 ] || echo -e "\n!! NB: running in DRY RUN mode ie. no action will actually be taken !!\n"
 
 disk="/dev/sdb"
 devname=$(basename $disk)
@@ -143,17 +149,17 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			if [ $VG -ne $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
-					lvremove -f $VG/$lv
+					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
 				done
-				vgremove -ff $VG
+				[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
 			fi
-			pvremove -ff -y /dev/$raid
+			[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid
 		elif [ $VERBOSE -ne 0 ]; then
 			echo -n "Delete RAID contents (Control-C aborts)? "
 			read $ans
 		fi
-		mdadm -S /dev/$raid
-		mdadm --zero-superblock --force /dev/$part 2>/dev/null
+		[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid
+		[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
 	else
 		# Standalone partition or part of a local RAID volume
 		if [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'BIOS boot')" ]; then
@@ -176,7 +182,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				echo -n "Delete RAID contents (Control-C aborts)? "
 				read $ans
 			fi
-			mdadm --zero-superblock --force /dev/$part 2>/dev/null
+			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
 		elif pvdisplay /dev/$part 2>/dev/null | grep -q "/dev/$part" ; then
 			VG=$(pvs --noheadings -o vg_name /dev/$part | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$part | tr -d " " | sort -u)
@@ -193,11 +199,11 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			if [ $VG -ne $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
-					lvremove -f $VG/$lv
+					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
 				done
-				vgremove -ff $VG
+				[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
 			fi
-			pvremove -ff -y /dev/$part
+			[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part
 		elif [ $VERBOSE -ne 0 ]; then
 			echo "Detected unrecognised partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
@@ -206,29 +212,33 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 	fi
 	if [ $VERBOSE -ne 0 ]; then
 		echo -n "Wiping partition /dev/$part ... "
-		wipefs -a /dev/$part
+		[ $DRY_RUN -eq 0 ] && wipefs -a /dev/$part
 		echo -e "done.\n"
 	else
-		wipefs -aq /dev/$part > /dev/null
+		[ $DRY_RUN -eq 0 ] && wipefs -aq /dev/$part > /dev/null
 	fi
 done
 if [ $VERBOSE -ne 0 ]; then
 	echo -n "Erase partition table of disk $disk (Control-C aborts)? "
 	read $ans
 	if $(partprobe -ds $disk | grep -q msdos); then
-		sfdisk --delete $disk
+		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk
 	else
-		sgdisk -Z -o $disk
+		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk
 	fi
-	wipefs -a $disk
+	[ $DRY_RUN -eq 0 ] && wipefs -a $disk
 else
 	if $(partprobe -ds $disk | grep -q msdos); then
-		sfdisk --delete $disk > /dev/null
+		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk > /dev/null
 	else
-		sgdisk -Z -o $disk > /dev/null
+		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk > /dev/null
 	fi
-	wipefs -aq $disk > /dev/null
+	[ $DRY_RUN -eq 0 ] && wipefs -aq $disk > /dev/null
 fi
-echo -e "\n\"Secondary\" disk $disk is hopefully now blank!"
+if [ $DRY_RUN -eq 0 ]; then
+	echo -e "\n\"Secondary\" disk $disk is hopefully now blank!"
+else
+	echo -e "\n\"Secondary\" disk $disk is hopefully _NOT_ blank! ;-)"
+fi
 
 exit 0

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -146,7 +146,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				echo -n "Delete RAID+LVM contents (Control-C aborts)? "
 				read $ans
 			fi
-			if [ $VG -ne $VG0 ]; then
+			if [ $VG != $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
 					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
@@ -196,7 +196,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				echo -n "Delete LVM contents (Control-C aborts)? "
 				read $ans
 			fi
-			if [ $VG -ne $VG0 ]; then
+			if [ $VG != $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
 					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv

--- a/RAID/blank_secondary
+++ b/RAID/blank_secondary
@@ -149,17 +149,34 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			if [ $VG != $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
-					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+					if [ $VERBOSE -ne 0 ]; then
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+					else
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null 2>&1
+					fi
 				done
-				[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+				if [ $VERBOSE -ne 0 ]; then
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+				else
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null 2>&1
+				fi
 			fi
-			[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid
+			if [ $VERBOSE -ne 0 ]; then
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid
+			else
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$raid > /dev/null 2>&1
+			fi
 		elif [ $VERBOSE -ne 0 ]; then
 			echo -n "Delete RAID contents (Control-C aborts)? "
 			read $ans
 		fi
-		[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid
-		[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
+		if [ $VERBOSE -ne 0 ]; then
+			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid
+			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
+		else
+			[ $DRY_RUN -eq 0 ] && mdadm -S /dev/$raid > /dev/null 2>&1
+			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part >/dev/null 2>&1
+		fi
 	else
 		# Standalone partition or part of a local RAID volume
 		if [ $VERBOSE -ne 0 ] && [ ! -z "$(sgdisk -i$partnum $disk | grep 'BIOS boot')" ]; then
@@ -181,8 +198,10 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 				mdadm --examine /dev/$part
 				echo -n "Delete RAID contents (Control-C aborts)? "
 				read $ans
+				[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
+			else
+				[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part > /dev/null 2>&1
 			fi
-			[ $DRY_RUN -eq 0 ] && mdadm --zero-superblock --force /dev/$part 2>/dev/null
 		elif pvdisplay /dev/$part 2>/dev/null | grep -q "/dev/$part" ; then
 			VG=$(pvs --noheadings -o vg_name /dev/$part | tr -d " ")
 			LVS=$(pvs --noheadings -o lv_name /dev/$part | tr -d " " | sort -u)
@@ -199,11 +218,23 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 			if [ $VG != $VG0 ]; then
 				# Only unwind LVM if _not_ our primary VG!!!
 				for lv in $LVS; do
-					[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+					if [ $VERBOSE -ne 0 ]; then
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv
+					else
+						[ $DRY_RUN -eq 0 ] && lvremove -f $VG/$lv > /dev/null 2>&1
+					fi
 				done
-				[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+				if [ $VERBOSE -ne 0 ]; then
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG
+				else
+					[ $DRY_RUN -eq 0 ] && vgremove -ff $VG > /dev/null 2>&1
+				fi
 			fi
-			[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part
+			if [ $VERBOSE -ne 0 ]; then
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part
+			else
+				[ $DRY_RUN -eq 0 ] && pvremove -ff -y /dev/$part > /dev/null 2>&1
+			fi
 		elif [ $VERBOSE -ne 0 ]; then
 			echo "Detected unrecognised partition: /dev/$part"
 			echo -n "Wipe partition (Control-C aborts)? "
@@ -215,7 +246,7 @@ for part in $(cd /dev/;ls $devname?* 2>/dev/null); do
 		[ $DRY_RUN -eq 0 ] && wipefs -a /dev/$part
 		echo -e "done.\n"
 	else
-		[ $DRY_RUN -eq 0 ] && wipefs -aq /dev/$part > /dev/null
+		[ $DRY_RUN -eq 0 ] && wipefs -aq /dev/$part > /dev/null 2>&1
 	fi
 done
 if [ $VERBOSE -ne 0 ]; then
@@ -229,11 +260,11 @@ if [ $VERBOSE -ne 0 ]; then
 	[ $DRY_RUN -eq 0 ] && wipefs -a $disk
 else
 	if $(partprobe -ds $disk | grep -q msdos); then
-		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk > /dev/null
+		[ $DRY_RUN -eq 0 ] && sfdisk --delete $disk > /dev/null 2>&1
 	else
-		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk > /dev/null
+		[ $DRY_RUN -eq 0 ] && sgdisk -Z -o $disk > /dev/null 2>&1
 	fi
-	[ $DRY_RUN -eq 0 ] && wipefs -aq $disk > /dev/null
+	[ $DRY_RUN -eq 0 ] && wipefs -aq $disk > /dev/null 2>&1
 fi
 if [ $DRY_RUN -eq 0 ]; then
 	echo -e "\n\"Secondary\" disk $disk is hopefully now blank!"

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.1.0 - May 2020
+Version 1.2.0 - June 2020
 
 :experimental:
 :toc:

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.1.6 - June 2020
+Version 1.2.0 - June 2020
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.1.1 - June 2020
+Version 1.2.0 - June 2020
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.1.0 - May 2020
+Version 1.1.1 - June 2020
 
 :sectnums:
 :experimental:
@@ -302,8 +302,9 @@ status of the RAID. It is most useful for checking whether a recovery
 is in process or has ended, but is also useful for showing the current
 state of the RAID, including any anomalies.
 
-The script also lists the serial numbers for all block devices (such
-as disks) that are currently connected.
+The script also lists various useful details for all block devices (such
+as disks) that are currently connected, including their model and serial
+numbers where applicable.
 
 === refresh_secondary
 
@@ -476,6 +477,12 @@ automatically be "Allowed" by both this script and
 *refresh_secondary*, which also supports this feature.  This allows
 you to then run *refresh_secondary* immediately without having to 
 *shutdown*, turn the disk off, reboot, start the script, and turn the disk on.
+
+NOTE: On the 32-bit *i386* platform, due to a broken *vgre,pve* binary, this
+script can give WARHINGs when erasing disks that were used for LVM.  These
+warnings can safely be ignored - ths disk will be successfully blanked (despite
+*vgremove* having segmentation-faulted instead of performing the requisite
+action thereby causing *pvremove* to complain about the VG still being active.)
 
 === recover_raid
 


### PR DESCRIPTION
I have updated blank_secondary to clear any LVM found on a RAID before attempting to remove the RAID itself.  I didn't add "set -e" because I use some commands in ways that may fail at times, but softened the concluding statement to reflect that things may not have worked.