### PR TITLE
Possible solution to RAID status active in drop_primary

### DIFF
--- a/RAID/drop_primary
+++ b/RAID/drop_primary
@@ -37,7 +37,7 @@ if [ ! -b /dev/md0 ]; then
         echo "ERROR: RAID /dev/md0 does not exist!!"
         exit 1
 fi
-if ! mdadm --detail /dev/md0 2>&1 | grep -q ": clean $" ; then
+if ! mdadm --detail /dev/md0 2>&1 | grep -qE ": (clean|active) $" ; then
         echo "ERROR: RAID /dev/md0 is not in a clean state!"
         exit 1
 fi

--- a/RAID/drop_primary
+++ b/RAID/drop_primary
@@ -38,7 +38,7 @@ if [ ! -b /dev/md0 ]; then
         exit 1
 fi
 if ! mdadm --detail /dev/md0 2>&1 | grep -qE ": (clean|active) $" ; then
-        echo "ERROR: RAID /dev/md0 is not in a clean state!"
+        echo "ERROR: RAID /dev/md0 is not in a clean or active state!"
         exit 1
 fi
 

--- a/RAID/recover_raid
+++ b/RAID/recover_raid
@@ -32,7 +32,7 @@ if [ ! -b $raid ]; then
 	exit 1
 fi
 
-if mdadm --detail $raid 2>&1 | grep -q ": clean $" ; then
+if mdadm --detail $raid 2>&1 | grep -qE ": (clean|active) $" ; then
 	echo "ERROR: RAID $raid does not need recovery!!"
 	exit 1
 fi

--- a/RAID/refresh_secondary
+++ b/RAID/refresh_secondary
@@ -48,7 +48,7 @@ if [ ! -b /dev/md0 ]; then
 	echo "ERROR: RAID /dev/md0 does not exist!!"
 	exit 1
 fi
-if mdadm --detail /dev/md0 2>&1 | grep -q ": clean $" ; then
+if mdadm --detail /dev/md0 2>&1 | grep -qE ": (clean|active) $" ; then
 	echo "ERROR: RAID /dev/md0 does not need recovery!!"
 	exit 1
 fi


### PR DESCRIPTION
Sometimes the RAID status comes back as " active " instead of " clean ". If that is benign, this may be is a solution. If not, maybe something else is needed. It seems to intermittently switch between " clean " and " active ", presumably depending on whether there is work to do. If it isn't benign, there may be a race condition depending on when it is checked.

Looking at how " clean " is used in (two) other scripts, this may not be a more a general issue, but maybe the expert should render a judgement.