### PR TITLE
Add ufw_re-enable service for CIS hardening

### DIFF
--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 NVI, Inc.
+// Copyright (c) 2020-2021 NVI, Inc.
 //
 // This file is part of the FSL10 Linux distribution.
 // (see http://github.com/nvi-inc/fsl10).
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.3.0 - October 2020
+Version 1.3.1 - March 2021
 
 :experimental:
 :toc:
@@ -394,6 +394,20 @@ The *root_tmp* script will do three things:
 
 There may be other issues with using the *noexec* option for */tmp*,
 but we don't have any specifics at this time.
+
+. Sometimes the firewall (UFW) does not work properly after rebooting.
+This has been noticed for remote access to _gromet_ for met. data on
+port 50001. There are no other known issues. An apparent fix for this
+is to disable and re-enable the firewall. If you have this problem and
+the same solution works, a one-time service at start-up can be created
+to perform this action:
+
+  cd /root/fsl10
+  ./create_ufw_re-enable
++
+
+The new service will run at the next reboot. It is configured to run
+_after_ UFW has been started.
 
 === Enabling user promotion to oper/prog and root
 

--- a/create_ufw_re-enable
+++ b/create_ufw_re-enable
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 NVI, Inc.
+#
+# This file is part of FSL10 Linux distribution.
+# (see http://github.com/nvi-inc/fsl10).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+set -e
+# create boot job to disable and then enable UFW
+#
+systemctl disable ufw_re-enable || :
+rm -f /etc/systemd/system/ufw_re-enable.service
+touch /etc/systemd/system/ufw_re-enable.service
+cat >>/etc/systemd/system/ufw_re-enable.service <<EOT
+[Unit]
+Description=Disable/re-enable ufw on startup
+After=ufw.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/ufw_re-enable
+RemainAfterExit=true
+
+[Install]
+WantedBy=multi-user.target
+EOT
+rm -f /usr/local/sbin/ufw_re-enable
+touch /usr/local/sbin/ufw_re-enable
+cat >> /usr/local/sbin/ufw_re-enable <<EOT
+#!/bin/bash
+set -e
+ufw disable
+ufw --force enable
+exit 0
+EOT
+chmod u+x /usr/local/sbin/ufw_re-enable
+systemctl enable ufw_re-enable.service

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.3.7 - March 2021
+Version 1.3.6 - January 2021
 
 :sectnums:
 :experimental:
@@ -1515,8 +1515,6 @@ The following tersely summarizes some *ufw* settings that may be useful:
 ufw allow OpenSSH
 #NTP
 ufw allow ntp
-#remote access to metserver (or gromet) on port 50001
-ufw allow 50001
 #anywhere from subnet
 ufw allow from 192.168.4.0/24
 #RDBE multicast to addresses from subnet

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.3.6 - January 2021
+Version 1.3.7 - March 2021
 
 :sectnums:
 :experimental:
@@ -1515,6 +1515,8 @@ The following tersely summarizes some *ufw* settings that may be useful:
 ufw allow OpenSSH
 #NTP
 ufw allow ntp
+#remote access to metserver (or gromet) on port 50001
+ufw allow 50001
 #anywhere from subnet
 ufw allow from 192.168.4.0/24
 #RDBE multicast to addresses from subnet


### PR DESCRIPTION
Extra security is the gift that keeps on giving.

For some reason _ufw_ doesn't respect the opening for remote access to _metserver_/_gromet_ after a reboot. Disabling and re-enabling _ufw_ fixes that. This PR creates an option to add a service to do that at start-up. It has been tested, but I am not sure how to tell that the `After=ufw.service` is really being obeyed. For a couple tries, the new service has  come after `ufw.service`.

Although technically I think this would require a feature release, I don't think we need one. The audience is small, basically me.

