### PR TITLE
Massively update refresh_spare_usr2

### DIFF
--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -24,7 +24,7 @@ set -e
 usage() {
     cat << EOF
 Usage: $0 [options]
-Refresh /usr2 on Spare machine
+Refresh '/usr2' on Spare machine
 
 Options:
  -f       Run in foreground
@@ -101,7 +101,7 @@ EOF
     fi
 
     if ! [ ${EUID:-`id -u`} = 0 ]; then
-       echo "You are not running with root privileges!"
+       echo "You are not running with 'root' privileges!"
        exit 1
     fi
 
@@ -123,7 +123,7 @@ EOF
 
 #--------------------- Comment out the next two lines ---------------------
 echo "This script must be customized before use.  See script for details."
-exit
+exit 1
 #--------------------------------------------------------------------------
 #
 # To customize this script (as 'root') on the Spare computer:
@@ -171,12 +171,12 @@ EOF
     exit
 fi
 
-echo "Refreshing spare computer disk /usr2 partition ..."
+echo "Refreshing spare computer disk '/usr2' partition ..."
 date="$(date)"
 echo "Starting at $date"
 if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
- echo "Can't proceed, /usr2 is not mounted"
- exit
+ echo "Can't proceed, '/usr2' is not mounted"
+ exit 1
 fi
 
 device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
@@ -204,13 +204,14 @@ echo ""
 if [[ -z "$background" ]]; then
     if [[ -n "$pv" ]]; then
         cat >/dev/tty << EOF
-    You may be prompted for your operational machine's root password twice and
-    then you will see a progess meter.
+    You may be prompted for your operational machine's 'root' password twice
+    and then you will see a progess meter.
 EOF
     else
        cat >/dev/tty << EOF
-    You may be prompted for your operational's machines root password once and
-    then there will be a long pause without any output unless there are errors.
+    You may be prompted for your operational's machines 'root' password once
+    and then there will be a long pause without any output unless there are
+    errors.
 EOF
     fi
     cat >/dev/tty << EOF

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -23,11 +23,85 @@ set -e
 
 usage() {
     cat << EOF
+
 Usage: $0 [options]
-Refresh '/usr2' on Spare machine
+This script refreshes '/usr2' on the Spare system.
 
 Options:
  -f       Run in foreground
+ -h       Help: this output
+ -s       Suppress sending email
+ -y       Yes: proceed without prompting for confirmation
+
+This is a script to refresh the contents of the Spare system '/usr2'
+partition if you have both an Operational and Spare systems.
+
+CAUTION: This script will automatically overwrite everything on the '/usr2'
+         partition of the system it is run on.  Use it only on the Spare
+         system.  It will stop any processes that are using the '/usr2'
+         partition.  Rebooting afterwards is recommended.
+
+This script must be executed by 'root' on the Spare system.  You must be
+logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
+and NOT have your working directory on '/usr2'.  If you promoted with 'su' or
+'sudo'/'root_account' that session may have its working directory on '/usr2'
+unless the '-f' option is used to refresh in foreground.  Make sure all other
+users are logged-out on both systems before using this script.
+
+This script must be customized before it is used.  There are direction for this
+embedded in the script.
+
+NOTE: If background mode (the default) is to be used, then the 'ssh' keys for
+      the 'root' account on the Spare system must be copied to the target
+      account on the Operational system.  In addition, the Operational system
+      must allow 'ssh' logins to that account from the Spare system.  If either
+      of these requirements can't be met, it should still be possible to use
+      the '-f' option to run the script in foreground mode.
+
+The script creates a log file of what happened during the refreshing operation
+in /root/refresh_spare_usr2_logs directory. The log file name includes a
+time-stamp of when the refresh was started.
+
+An email is sent to 'root' with the log file contents when the script finishes.
+
+The refresh is normally performed in the background.  When it is first
+installed on a system, it is recommended to run it in the foreground with the
+'-f' option to verify that it is working and get an idea how long the transfer
+will take.  It usually only takes a few minutes for newly installed systems,
+but that will gradually increase as '/usr2' on the Operational system
+accumulates more data.  The actual transfer time will be shown on the screen in
+foreground mode.  For either mode, it can also be found in the log file on
+disk, which is typically emailed to 'root' as well, when the script finishes.
+It is recommended to check and be aware of how how long the transfers have
+taken, so you know about how long to expect the next transfer to take.
+
+For background refreshes, verify that it has finished, either from the log file
+or an email, before performing the finishing up steps: checking that 'mdstat'
+does not show an active recovery and then rebooting.  Those finishing up steps
+are also need for foreground mode, but it should be apparent from the screen
+output when the refresh has finished.
+
+The critical phase of operation of the script occurs between the printing of
+
+    Starting critical phase. Executing "umount /usr2" ...
+
+and
+
+    ... completed "mount /usr2". The critical phase is finished.
+
+If the script is interrupted or otherwise fails between these commands, it will
+usually be necessary to take corrective action.  This normally consists of
+re-executing (using copy-and-paste) the contents (everything from between the
+double quotes, typically a long string) of the output line
+
+    Executing "mke2fs -F -t ..."
+
+That line is printed during the critical phase and can be found in the log
+file, or if the '-f' option was used, may be visible on the screen.  If the
+re-execution of 'mke2fs ...' fails because '/usr2' is mounted, you will need to
+execute 'umount /usr2' before trying again.  After 'mke2fs' has been
+re-executed successfully, execute 'mount /usr2' and try the script again.
+
 EOF
 }
 
@@ -50,17 +124,30 @@ safe_pv() {
     fi
 }
 background=1
-while getopts f opt; do
+proceed=
+send_email=1
+while getopts fhsy opt; do
     case $opt in
         f)
             background=
             ;;
+        h)
+            usage
+            exit
+            ;;
+        s)
+            send_email=
+            ;;
+        y)
+            proceed=1
+            ;;
         *)
-            usage >&2
+            echo "Use '$0 -h' for help" >&2
             exit 1
             ;;
         :)
-          fatal "Option -$OPTARG requires an argument."
+            echo "Use '$0 -h' for help" >&2
+            exit 1
           ;;
     esac
 done
@@ -75,26 +162,7 @@ fi
 log=$2
 
 if [[ -z "$subscript" ]]; then
-    cat << EOF
-***************************************************************************
-*  This is a script to refresh the contents of the spare computer '/usr2' *
-*  partition if you have both an Operational and Spare computer.  Please  *
-*  refer to: https://nvi-inc.github.io/fsl10/raid.html for more details.  *
-***************************************************************************
 
-CAUTION: This script will automatically overwrite everything on the '/usr2'
-         partition of the computer it is run on.  Use it only on the Spare
-         computer.  It will stop any processes that are using the '/usr2'
-         partition.  Rebooting afterwards is recommended.
-
-This script must be executed by 'root' on the Spare computer.  You must be
-logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
-and NOT have your working directory on '/usr2'.  If you promoted with 'su' or
-'sudo'/'root_account' that session may have its working directory on '/usr2'
-unless the '-f' option is used to refresh in foreground.  Make sure all other
-users are logged-out on both computers before proceeding.
-
-EOF
     if [[ "$PWD/" =~ ^/usr2/ ]]; then
        echo "You are on '/usr2'. Try again, but 'cd /tmp' first."
        exit 1
@@ -105,29 +173,39 @@ EOF
        exit 1
     fi
 
-    echo -e "Do you wish to continue with the REFRESH? (y=yes, n=no) : \c"
-    badans=true
-    while [ "$badans" = "true" ]
-    do
-      read ans
-      case "$ans" in
-        y|yes) echo -e "\nO.K. Continuing with refresh ... "
-               badans=false
-               ;;
-        n|no)  echo -e "\nO.K. Exiting."
-               exit
-               ;;
-        *)     echo -e "\nPlease answer with y=yes or n=no : \c"
-      esac
-    done
+    if [[ -z "$proceed" ]]; then
+
+        cat << EOF
+
+    IMPORTANT: No one else should be logged into this system and no one should
+               be logged into the Operational system.
+
+EOF
+
+        echo -e "Is it okay to proceed with refreshing '/usr2'? (y=yes, n=no) : \c"
+        badans=true
+        while [ "$badans" = "true" ]
+        do
+          read ans
+          case "$ans" in
+            y|yes) echo -e "\nO.K. Continuing with refresh ... "
+                   badans=false
+                   ;;
+            n|no)  echo -e "\nO.K. Exiting."
+                   exit
+                   ;;
+            *)     echo -e "\nPlease answer with y=yes or n=no : \c"
+          esac
+        done
+    fi
 
 #--------------------- Comment out the next two lines ---------------------
 echo "This script must be customized before use.  See script for details."
 exit 1
 #--------------------------------------------------------------------------
 #
-# To customize this script (as 'root') on the Spare computer:
-#   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE COMPUTER.
+# To customize this script (as 'root') on the Spare system:
+#   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE SYSTEM.
 #   2. Execute the commands:
 #        cd /usr/local/sbin
 #        cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
@@ -135,12 +213,17 @@ exit 1
 #        chmod a+r,u+wx,go-wx refresh_spare_usr2
 #   3. Edit '/usr/local/sbin/refresh_spare_usr2':
 #        A. Comment out the two commands above (add leading '#'s).
-#        B  Change the 'operational' in the 'node=operational' line below
-#           to the alias (preferred), FQDN, or IP address of your
-#           operational machine.
+#        B  Change the 'operational' in the 'remote_node=operational' line
+#           below to the alias (preferred), FQDN, or IP address of your
+#           Operational system  (There are additional instructions a little
+#           after that line for more customizations for CIS hardened systems.)
 #        C. Save the result.
-#   4. Test it the first time just after the Spare computer's disk have
-#      been rotated.
+#   4. For background operation, the 'ssh' keys for 'root' on the Spare
+#      system must be copied to the target account on the Operational system.
+#      The Operational system must also allow 'ssh' connections to that
+#      account from the Spare system.
+#   5. Test it the first time just after the Spare system's disk has been
+#      rotated.
 #
 
 # setup for log file
@@ -154,26 +237,48 @@ exit 1
         cat << EOF
 
     Going to background, you should log out now or you may be logged out
-    automatically.  Don't login again to either computer until you expect the
-    'refresh_spare_usr2' to have finished.  An email with the log file will be
-    sent to 'root' when the script finishes.
+    automatically.  Don't login again to either system until you expect the
+    'refresh_spare_usr2' to have finished.
+
+    After it has finished wait until 'mdstat' does not show an active recovery
+    and then reboot.
 
 EOF
+
+        if [[ -n "$send_email" ]]; then
+            cat << EOF
+An email with the log file will be sent to 'root' when the script finishes.
+
+EOF
+        fi
         echo "Log file is $log"
         echo ""
-        nohup "$0" "$special" "$log" 1>>$log 2>&1 &
+        if [[ -z "$send_email" ]]; then
+            nohup "$0" -s "$special" "$log" 1>>$log 2>&1 &
+        else
+            nohup "$0"    "$special" "$log" 1>>$log 2>&1 &
+        fi
     else
         echo ""
         echo "Log file is $log"
         echo ""
-        "$0" -f "$special" "$log" 2>&1 |tee "$log"
+        if [[ -z "$send_email" ]]; then
+            options=-fs
+        else
+            options=-f
+        fi
+        "$0" "$options" "$special" "$log" 2>&1 |tee "$log"
     fi
     exit
 fi
 
-echo "Refreshing spare computer disk '/usr2' partition ..."
+if [[ -z "$background" ]]; then
+    echo "Refreshing Spare system disk '/usr2' partition in foreground ..."
+else
+    echo "Refreshing Spare system disk '/usr2' partition in background ..."
+fi
 date="$(date)"
-echo "Starting at $date"
+echo "Started at $date"
 if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
  echo "Can't proceed, '/usr2' is not mounted"
  exit 1
@@ -188,29 +293,35 @@ if [[ -z "$background" ]]; then
     If you are logged out automatically, the 'refresh_spare_usr2' failed.  You
     were probably on '/usr2' before you switched to 'root'.  Try again, but
     'cd /tmp' before switching to 'root'.
-
 EOF
 fi
 
 fuser -k -M -m /usr2 || :
+
+echo ""
+echo "Starting critical phase. Executing \"umount /usr2\" ..."
+echo ""
 umount /usr2
 UUID=$(tune2fs -l $device | grep UUID | grep -o '[^ ]*$')
-echo "Executing \"mke2fs -F -t $type -U $UUID $device\" ..."
+echo "Executing \"mke2fs -F -t $type -U $UUID $device\""
+echo ""
 mke2fs -F -t $type -U $UUID $device
 mount /usr2
-echo "Completed \"mount /usr2\""
+echo "... completed \"mount /usr2\".  The critical phase is finished."
 echo ""
 
 if [[ -z "$background" ]]; then
     if [[ -n "$pv" ]]; then
         cat >/dev/tty << EOF
-    You may be prompted for your operational machine's 'root' password twice
-    and then you will see a progess meter.
+    You may see two login messages for your Operational system.  If you are
+    prompted for the 'root' or other password on that system each time, you
+    should provide it.  Then you will see a progess meter during the transfer.
 EOF
     else
        cat >/dev/tty << EOF
-    You may be prompted for your operational's machines 'root' password once
-    and then there will be a long pause without any output unless there are
+    You may see a login message for your Operational system  If you are
+    prompted for the 'root' or other password on that system you should provide
+    it.  Then there will be a long pause without any output unless there are
     errors.
 EOF
     fi
@@ -218,28 +329,39 @@ EOF
 
     When the transfer finishes, a summary of the transfer will be printed and
     you will see a line that starts: 'Done. ...', and get a prompt. Please
-    follow the directions on the 'Done. ...' line.  An email with the log file
-    will be sent to 'root' when the script finishes.
+    follow the directions on the 'Done. ...' line.
 
 EOF
+    if [[ -n "$send_email" ]]; then
+        cat >/dev/tty << EOF
+    An email with the log file will be sent to 'root' when the script finishes.
+
+EOF
+    fi
 fi
 
 cat << EOF
-    If there are errors, please note them and report them at
+    If there are errors, please report them at
     https://github.com/nvi-inc/fsl10/issues.
 
 EOF
 
-user=root
-node=operational
+remote_user=root
+# Use your Operational system name in place of 'operational' in the next line
+remote_node=operatonal
+remote_command='cd /usr2; tar --one-file-system -cf - .'
+
+# Uncomment the next two lines for CIS hardened systems
+#remote_user=spare
+#remote_command='sudo send_usr2'
 
 if [[ -n "$pv" && -z "$background" ]]; then
-    size="$(ssh $user@$node df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
+    size="$(ssh $remote_user@$remote_node df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
 else
     size=
 fi
 
-time ssh "$user@$node" 'cd /usr2; tar --one-file-system -cf - .' | safe_pv | (cd /usr2; tar xpf - --totals)
+time ssh "$remote_user@$remote_node" "$remote_command" | safe_pv | (cd /usr2; tar xpf - --totals)
 
 cat << EOF
 
@@ -247,8 +369,10 @@ Done. Wait until 'mdstat' does not show an active recovery and then reboot.
 EOF
 
 if [[ -z "$background" ]]; then
-    cat "$log" | /usr/bin/mail -s "foreground refresh_spare_usr2 finished" root &
+    if [[ -n "$send_email" ]]; then
+        cat "$log" | /usr/bin/mail -s "foreground refresh_spare_usr2 finished" root &
+    fi
     echo "" >/dev/tty
-else
+elif [[ -n "$send_email" ]]; then
     cat "$log" | /usr/bin/mail -s "background refresh_spare_usr2 finished" root
 fi

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -90,17 +90,27 @@ The script may take up to three times longer to complete if both the
 Operational and Spare systems are refreshing their secondary disks concurrently
 than when the systems are quiescent.
 
-INSTALLATION
+USING THE SYSTEMS WHILE THE SCRIPT IS RUNNING
 
-This script must be customized before it is used.  Directions for that are
-embedded in the script.
+Do not login to an account on the spare system with a home directory on the
+'/usr2' partition (logging in as 'root' on a text console is okay) or otherwise
+access that partition during the refresh.
 
-It may not be possible to setup the script to login into the Operational system
-with 'ssh' keys.  If not, it may still be possible to connect with a password;
-in which case, the script will only work if used with '-f', foreground mode.
-Using the CIS hardening approach may be a usable alternative if there are
-obstacles with using 'ssh' keys to log into the 'root' account.  See the
-comments in the script for more information.
+It is possible to use the operational system during the refresh if necessary,
+but this should be avoided if possible and activity on the '/usr2' partition
+should be as limited as possible.  You should not expect any changes on the
+operational system '/usr2' that occur after the refresh starts to be propagated
+to the spare system.  If any files on the operational system '/usr2' are
+deleted from it before they could be copied, there may be error messages like:
+
+  tar: ...: Cannot stat: No such file or directory
+
+for those files (named in place of the '...') and a final summary error
+message:
+
+  tar: Exiting with failure status due to previous errors
+
+but without other errors the refresh should still generally succeed.
 
 CRITICAL PHASE
 
@@ -125,6 +135,18 @@ file, or if the '-f' option was used, may be visible on the screen.  If the
 re-execution of 'mke2fs ...' fails because '/usr2' is mounted, you will need to
 execute 'umount /usr2' before trying again.  After 'mke2fs' has been
 re-executed successfully, execute 'mount /usr2' and try the script again.
+
+INSTALLATION
+
+This script must be customized before it is used.  Directions for that are
+embedded in the script.
+
+It may not be possible to setup the script to login into the Operational system
+with 'ssh' keys.  If not, it may still be possible to connect with a password;
+in which case, the script will only work if used with '-f', foreground mode.
+Using the CIS hardening approach may be a usable alternative if there are
+obstacles with using 'ssh' keys to log into the 'root' account.  See the
+comments in the script for more information.
 
 EOF
 }
@@ -266,11 +288,14 @@ exit 1
         cat << EOF
 
     Going to background, you should log out now or you may be logged out
-    automatically.  Don't login again to either system until you expect the
-    'refresh_spare_usr2' to have finished.
+    automatically.
 
-    After it has finished wait until 'mdstat' does not show an active recovery
-    and then reboot.
+    It is best to NOT login into either the spare or operational system while
+    'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
+    SCRIPT IS RUNNING' section of the '-h' help output for more details.
+
+    After the refresh has finished wait, until 'mdstat' does not show an active
+    recovery and then reboot.
 
 EOF
 
@@ -357,6 +382,10 @@ EOF
 EOF
     fi
     cat >/dev/tty << EOF
+
+    It is best to NOT login into either the spare or operational system while
+    'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
+    SCRIPT IS RUNNING' section of the '-h' help output for more details.
 
     When the transfer finishes, a summary of the transfer will be printed and
     you will see a line that starts: 'Done. ...', and get a prompt. Please

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -43,33 +43,49 @@ CAUTION: This script will automatically overwrite everything on the '/usr2'
 
 This script must be executed by 'root' on the Spare system.  You must be
 logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
-and NOT have your working directory on '/usr2'.  If you promoted with 'su' or
-'sudo'/'root_account', that session may have its working directory on '/usr2'
-unless the '-f' option is used to refresh in foreground.  Make sure all other
-users are logged-out on both systems before using this script.
+and NOT have your working directory on '/usr2'.  Make sure all other users are
+logged-out on both systems before using this script.
+
+To run the script, it is recommended to log in as 'root' on a text console or
+'ssh' into the machine using a non-'root' account, 'cd /tmp', and finally
+promote to 'root'.
+
+If the '-f' option is used to refresh in foreground and you promoted to 'root',
+then the original session must not have its working directory on '/usr2', nor
+be an X session opened by an account that has its home directory on '/usr2'.  A
+refresh will work for both of those cases without the '-f' option, but you will
+be abruptly logged out when the refresh starts.
 
 This script must be customized before it is used.  Directions for that are
 embedded in the script.
 
-For foreground refreshes, a progress meter with an ETA will be displayed if the
+WARNING: It may not be possible to setup the script to login into the
+         Operational system with 'ssh' keys.  It may still be possible to
+         connect with a password; in which case, the script will only work if
+         used with '-f', foreground mode.  Using the CIS hardening approach may
+         be a usable alternative if there are obstacles with using 'ssh' keys
+         to log into the 'root' account.  See the comments in the script for
+         more information,
+
+For foreground refreshes, a progress bar with an ETA will be displayed if the
 'pv' package is installed.
 
-The script creates a log file of what happened during the refreshing operation
-in /root/refresh_spare_usr2_logs directory. The log file name includes a
+The script creates a log file of what happened during the refresh operation in
+'/root/refresh_spare_usr2_logs' directory. The log file name includes a
 time-stamp of when the refresh was started.
 
 An email is sent to 'root' with the log file contents when the script finishes.
 
-The refresh is normally performed in the background.  When it is first
-installed on a system, it is recommended to run it in the foreground with the
-'-f' option to verify that it is working and get an idea how long the transfer
-will take.  It usually only takes a few minutes for newly installed systems,
-but that will gradually increase as '/usr2' on the Operational system
+The refresh is normally performed in background.  When the script is first
+installed on a system, it is recommended to run it in foreground with the '-f'
+option to verify that it is working and get an idea how long the transfer will
+take.  It usually only takes a few minutes for newly installed systems.  The
+time required will gradually increase as '/usr2' on the Operational system
 accumulates more data.  The actual transfer time will be shown on the screen in
 foreground mode.  For either mode, it can also be found in the log file on
 disk, which is typically emailed to 'root' as well, when the script finishes.
-It is recommended to check and be aware of how how long the transfers have
-taken, so you know about how long to expect the next transfer to take.
+It is recommended to check and be aware of how how long transfers take, so you
+know about how long to expect the next transfer to take.
 
 For background refreshes, verify that it has finished, either from the log file
 or an email, before performing the finishing up steps: checking that 'mdstat'
@@ -88,7 +104,8 @@ and
 If the script is interrupted or otherwise fails between these commands, it will
 usually be necessary to take corrective action.  This normally consists of
 re-executing (using copy-and-paste) the contents (everything from between the
-double quotes, typically a long string) of the output line
+double quotes, typically a long string, it will probably overwrap your terminal
+width) of the output line
 
     Executing "mke2fs -F -t ..."
 
@@ -102,7 +119,7 @@ EOF
 }
 
 # Check if pv (Pipe Viewer) is installed.
-# Used for progress meter
+# Used for progress bar
 if command -v pv &> /dev/null; then
     pv=$(which pv)
 else
@@ -218,7 +235,11 @@ exit 1
 #      target account on the Operational system.  That system should also be
 #      set to allow 'ssh' connections to that account from the Spare system.
 #      If these two things cannot be done, the target account must allow
-#      password login; in which case, background operation will not function.
+#      password login; in which case, only '-f', foreground mode, will be
+#      usable.  The CIS hardening approach may be a useful alternative if there
+#      are problems with using 'ssh' keys to log into the 'root' account.  For
+#      more information, see:
+#      https://nvi-inc.github.io/fsl10/cis-setup.html#_refresh_spare_usr2_with_cis_hardening_setup
 #   5. Test it the first time just after the Spare system's disk has been
 #      rotated.
 #
@@ -276,6 +297,8 @@ else
 fi
 date="$(date)"
 echo "Started at $date"
+echo ""
+
 if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
  echo "Can't proceed, '/usr2' is not mounted"
  exit 1
@@ -286,16 +309,16 @@ type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
 
 if [[ -z "$background" ]]; then
     cat << EOF
+    IMPORTANT: If you are logged out automatically, the refresh FAILED.  You
+               were probably on '/usr2' before you promoted to 'root'.  Try
+               again, but 'cd /tmp' before promoting to 'root'.
 
-    If you are logged out automatically, the 'refresh_spare_usr2' failed.  You
-    were probably on '/usr2' before you switched to 'root'.  Try again, but
-    'cd /tmp' before switching to 'root'.
 EOF
 fi
 
 fuser -k -M -m /usr2 || :
+sleep 1
 
-echo ""
 echo "Starting critical phase. Executing \"umount /usr2\" ..."
 echo ""
 umount /usr2
@@ -312,7 +335,7 @@ if [[ -z "$background" ]]; then
         cat >/dev/tty << EOF
     You may see two login messages from your Operational system.  If you are
     prompted for the 'root' or other password on that system (twice), you
-    should provide it.  Then you will see a progress meter during the transfer.
+    should provide it.  Then you will see a progress bar during the transfer.
 EOF
     else
        cat >/dev/tty << EOF
@@ -344,9 +367,10 @@ cat << EOF
 EOF
 
 remote_user=root
+remote_command='cd /usr2; tar --one-file-system -cf - .'
+
 # Use your Operational system name in place of 'operational' in the next line
 remote_node=operational
-remote_command='cd /usr2; tar --one-file-system -cf - .'
 
 # Uncomment the next two lines for CIS hardened systems
 #remote_user=spare

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -33,8 +33,8 @@ Options:
  -s       Suppress sending email
  -y       Yes: proceed without prompting for confirmation
 
-This is a script to refresh the contents of the Spare system '/usr2'
-partition if you have both an Operational and Spare systems.
+This is a script to refresh the contents of the Spare system '/usr2' partition
+if you have both Operational and Spare systems.
 
 CAUTION: This script will automatically overwrite everything on the '/usr2'
          partition of the system it is run on.  Use it only on the Spare
@@ -44,19 +44,15 @@ CAUTION: This script will automatically overwrite everything on the '/usr2'
 This script must be executed by 'root' on the Spare system.  You must be
 logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
 and NOT have your working directory on '/usr2'.  If you promoted with 'su' or
-'sudo'/'root_account' that session may have its working directory on '/usr2'
+'sudo'/'root_account', that session may have its working directory on '/usr2'
 unless the '-f' option is used to refresh in foreground.  Make sure all other
 users are logged-out on both systems before using this script.
 
-This script must be customized before it is used.  There are direction for this
+This script must be customized before it is used.  Directions for that are
 embedded in the script.
 
-NOTE: If background mode (the default) is to be used, then the 'ssh' keys for
-      the 'root' account on the Spare system must be copied to the target
-      account on the Operational system.  In addition, the Operational system
-      must allow 'ssh' logins to that account from the Spare system.  If either
-      of these requirements can't be met, it should still be possible to use
-      the '-f' option to run the script in foreground mode.
+For foreground refreshes, a progress meter with an ETA will be displayed if the
+'pv' package is installed.
 
 The script creates a log file of what happened during the refreshing operation
 in /root/refresh_spare_usr2_logs directory. The log file name includes a
@@ -118,9 +114,9 @@ safe_pv() {
         cat
     elif [[ ! "$size" =~ ^[1-9][0-9]*k$ ]]; then
 # defensive
-        $pv --force 2>/dev/tty
+        $pv -W 2>/dev/tty
     else
-        $pv --force -s "$size" 2>/dev/tty
+        $pv -W -s "$size" 2>/dev/tty
     fi
 }
 background=1
@@ -218,10 +214,11 @@ exit 1
 #           Operational system  (There are additional instructions a little
 #           after that line for more customizations for CIS hardened systems.)
 #        C. Save the result.
-#   4. For background operation, the 'ssh' keys for 'root' on the Spare
-#      system must be copied to the target account on the Operational system.
-#      The Operational system must also allow 'ssh' connections to that
-#      account from the Spare system.
+#   4. The 'ssh' keys for 'root' on the Spare system should be copied to the
+#      target account on the Operational system.  That system should also be
+#      set to allow 'ssh' connections to that account from the Spare system.
+#      If these two things cannot be done, the target account must allow
+#      password login; in which case, background operation will not function.
 #   5. Test it the first time just after the Spare system's disk has been
 #      rotated.
 #
@@ -313,16 +310,16 @@ echo ""
 if [[ -z "$background" ]]; then
     if [[ -n "$pv" ]]; then
         cat >/dev/tty << EOF
-    You may see two login messages for your Operational system.  If you are
-    prompted for the 'root' or other password on that system each time, you
-    should provide it.  Then you will see a progess meter during the transfer.
+    You may see two login messages from your Operational system.  If you are
+    prompted for the 'root' or other password on that system (twice), you
+    should provide it.  Then you will see a progress meter during the transfer.
 EOF
     else
        cat >/dev/tty << EOF
-    You may see a login message for your Operational system  If you are
-    prompted for the 'root' or other password on that system you should provide
-    it.  Then there will be a long pause without any output unless there are
-    errors.
+    You may see a login message from your Operational system  If you are
+    prompted for the 'root' or other password on that system, you should
+    provide it.  Then there will be a long pause without any output unless
+    there are errors.
 EOF
     fi
     cat >/dev/tty << EOF
@@ -348,7 +345,7 @@ EOF
 
 remote_user=root
 # Use your Operational system name in place of 'operational' in the next line
-remote_node=operatonal
+remote_node=operational
 remote_command='cd /usr2; tar --one-file-system -cf - .'
 
 # Uncomment the next two lines for CIS hardened systems

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -101,7 +101,7 @@ EOF
     fi
 
     if ! [ ${EUID:-`id -u`} = 0 ]; then
-       echo "You are not running with root priviledges!"
+       echo "You are not running with root privileges!"
        exit 1
     fi
 
@@ -127,7 +127,7 @@ exit
 #--------------------------------------------------------------------------
 #
 # To customize this script (as 'root') on the Spare computer:
-#   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE COMPUTER
+#   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE COMPUTER.
 #   2. Execute the commands:
 #        cd /usr/local/sbin
 #        cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
@@ -135,9 +135,10 @@ exit
 #        chmod a+r,u+wx,go-wx refresh_spare_usr2
 #   3. Edit '/usr/local/sbin/refresh_spare_usr2':
 #        A. Comment out the two commands above (add leading '#'s).
-#        B  Change the 'operational' on the TWO ssh command below to the
-#           alias, FQDN, or IP address of your operational machine
-#        C. Save the results
+#        B  Change the 'operational' in the 'node=operational' line below
+#           to the alias (preferred), FQDN, or IP address of your
+#           operational machine.
+#        C. Save the result.
 #   4. Test it the first time just after the Spare computer's disk have
 #      been rotated.
 #
@@ -222,13 +223,16 @@ cat << EOF
 
 EOF
 
+user=root
+node=operational
+
 if [[ -n "$pv" && -z "$background" ]]; then
-    size="$(ssh root@operational df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
+    size="$(ssh $user@$node df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
 else
     size=
 fi
 
-time ssh root@operational 'cd /usr2; tar --one-file-system -cf - .' | safe_pv | (cd /usr2; tar xpf - --totals)
+time ssh "$user@$node" 'cd /usr2; tar --one-file-system -cf - .' | safe_pv | (cd /usr2; tar xpf - --totals)
 
 cat << EOF
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -44,9 +44,9 @@ safe_pv() {
         cat
     elif [[ ! "$size" =~ ^[1-9][0-9]*k$ ]]; then
 # defensive
-        $pv
+        $pv --force 2>/dev/tty
     else
-        $pv -s "$size"
+        $pv --force -s "$size" 2>/dev/tty
     fi
 }
 background=1
@@ -142,6 +142,14 @@ exit
 #   4. Test it the first time just after the Spare computer's disk have
 #      been rotated.
 #
+
+# setup for log file
+    dir=/root/refresh_spare_usr2_logs
+    if [[ ! -d  "$dir" ]]; then
+       mkdir "$dir"
+    fi
+    log="$dir/$(date +"%Y.%b.%d.%H.%M.%S")".log
+
     if [[ -n "$background" ]]; then
         cat << EOF
 
@@ -151,18 +159,16 @@ exit
     sent to 'root' when the script finishes.
 
 EOF
-        dir=/root/refresh_spare_usr2_logs
-        if [[ ! -d  "$dir" ]]; then
-           mkdir "$dir"
-        fi
-        log="$dir/$(date +"%Y.%b.%d.%H.%M.%S")".log
         echo "Log file is $log"
         echo ""
-        exec 1>>$log
-        exec 2>&1
-        nohup "$0" "$special" "$log" &
-        exit
+        nohup "$0" "$special" "$log" 1>>$log 2>&1 &
+    else
+        echo ""
+        echo "Log file is $log"
+        echo ""
+        "$0" -f "$special" "$log" 2>&1 |tee "$log"
     fi
+    exit
 fi
 
 echo "Refreshing spare computer disk /usr2 partition ..."
@@ -176,7 +182,7 @@ fi
 device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
 type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
 
-if [[ -z "$subscript" ]]; then
+if [[ -z "$background" ]]; then
     cat << EOF
 
     If you are logged out automatically, the 'refresh_spare_usr2' failed.  You
@@ -195,24 +201,24 @@ mount /usr2
 echo "Completed \"mount /usr2\""
 echo ""
 
-if [[ -z "$subscript" ]]; then
+if [[ -z "$background" ]]; then
     if [[ -n "$pv" ]]; then
-        cat << EOF
+        cat >/dev/tty << EOF
     You may be prompted for your operational machine's root password twice and
     then you will see a progess meter.
 EOF
     else
-       cat << EOF
+       cat >/dev/tty << EOF
     You may be prompted for your operational's machines root password once and
     then there will be a long pause without any output unless there are errors.
 EOF
     fi
-    cat << EOF
+    cat >/dev/tty << EOF
 
     When the transfer finishes, a summary of the transfer will be printed and
     you will see a line that starts: 'Done. ...', and get a prompt. Please
-    follow the directions on the 'Done. ...' line.  An email will be sent to
-    'root' when the script finishes.
+    follow the directions on the 'Done. ...' line.  An email with the log file
+    will be sent to 'root' when the script finishes.
 
 EOF
 fi
@@ -239,9 +245,9 @@ cat << EOF
 Done. Wait until 'mdstat' does not show an active recovery and then reboot.
 EOF
 
-if [[ -z "$subscript" ]]; then
-    echo ""
-    echo "Started at $date" | /usr/bin/mail -s "foreground refresh_spare_usr2 finished" root
+if [[ -z "$background" ]]; then
+    cat "$log" | /usr/bin/mail -s "foreground refresh_spare_usr2 finished" root &
+    echo "" >/dev/tty
 else
     cat "$log" | /usr/bin/mail -s "background refresh_spare_usr2 finished" root
 fi

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 NVI, Inc.
+# Copyright (c) 2020-2021 NVI, Inc.
 #
 # This file is part of FSL10 Linux distribution.
 # (see http://github.com/nvi-inc/fsl10).
@@ -20,50 +20,113 @@
 #
 
 set -e
-echo "*******************************************************************"
-echo "*  This is a script to refresh the contents of the spare computer *"
-echo "*    '/usr2' partition if you have both an Operational and Spare  *"
-echo "*    computer. Please refer to:                                   *"
-echo "*      https://nvi-inc.github.io/fsl10/raid.html                  *"
-echo "*    for more information.                                        *"
-echo "*******************************************************************"
-echo ""
-echo "CAUTION: This script will automatically overwrite everything on the"
-echo "         /usr2 partition of the computer it is run on.  Use it only"
-echo "         on the Spare computer.  It will stop any processes that"
-echo "         are using the /usr2 partition.  Rebooting afterwards is"
-echo "         recommended."
-echo ""
-echo "This script must be executed by 'root' on the Spare computer. "
-echo "You must be logged-in as 'root', do not use 'su', 'ssh', or"
-echo "'sudo/'root_account' to  become 'root' locally.  Remote login"
-echo "via 'ssh' as 'root' is okay, if that is permitted.  Make sure"
-echo "all other users are logged-out before proceeding."
-echo ""
-if ! [ ${EUID:-`id -u`} = 0 ]; then
-   echo "You are not running with root priviledges!"
-   exit 1
+
+usage() {
+    cat << EOF
+Usage: $0 [options]
+Refresh /usr2 on Spare machine
+
+Options:
+ -f       Run in foreground
+EOF
+}
+
+# Check if pv (Pipe Viewer) is installed.
+# Used for progress meter
+if command -v pv &> /dev/null; then
+    pv=$(which pv)
+else
+    pv=
 fi
-echo -e "Do you wish to continue with the REFRESH? (y=yes, n=no) : \c" 
-badans=true
-while [ "$badans" = "true" ]
-do
-  read ans
-  case "$ans" in
-    y|yes) echo -e "\nO.K. Continuing with refresh ... "
-           badans=false
-           ;;
-    n|no)  echo -e "\nO.K. Exiting."
-           exit
-           ;;
-    *)     echo -e "\nPlease answer with y=yes or n=no : \c"
-  esac
+
+safe_pv() {
+    if [[ -z "$pv" || -n "$background" ]]; then
+        cat
+    elif [[ ! "$size" =~ ^[1-9][0-9]*k$ ]]; then
+# defensive
+        $pv
+    else
+        $pv -s "$size"
+    fi
+}
+background=1
+while getopts f opt; do
+    case $opt in
+        f)
+            background=
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+        :)
+          fatal "Option -$OPTARG requires an argument."
+          ;;
+    esac
 done
-#------------- Comment out these two lines ----------------
-echo "This script must be customized before first use, and it hasn't been."
-echo "See script for details."
+shift $((OPTIND - 1))
+
+special=special_arg_to_run_subscript
+subscript=
+if [[ "$1" = "$special" ]]; then
+  subscript=1
+fi
+
+log=$2
+
+if [[ -z "$subscript" ]]; then
+    cat << EOF
+***************************************************************************
+*  This is a script to refresh the contents of the spare computer '/usr2' *
+*  partition if you have both an Operational and Spare computer.  Please  *
+*  refer to: https://nvi-inc.github.io/fsl10/raid.html for more details.  *
+***************************************************************************
+
+CAUTION: This script will automatically overwrite everything on the '/usr2'
+         partition of the computer it is run on.  Use it only on the Spare
+         computer.  It will stop any processes that are using the '/usr2'
+         partition.  Rebooting afterwards is recommended.
+
+This script must be executed by 'root' on the Spare computer.  You must be
+logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
+and NOT have your working directory on '/usr2'.  If you promoted with 'su' or
+'sudo'/'root_account' that session may have its working directory on '/usr2'
+unless the '-f' option is used to refresh in foreground.  Make sure all other
+users are logged-out on both computers before proceeding.
+
+EOF
+    if [[ "$PWD/" =~ ^/usr2/ ]]; then
+       echo "You are on '/usr2'. Try again, but 'cd /tmp' first."
+       exit 1
+    fi
+
+    if ! [ ${EUID:-`id -u`} = 0 ]; then
+       echo "You are not running with root priviledges!"
+       exit 1
+    fi
+
+    echo -e "Do you wish to continue with the REFRESH? (y=yes, n=no) : \c"
+    badans=true
+    while [ "$badans" = "true" ]
+    do
+      read ans
+      case "$ans" in
+        y|yes) echo -e "\nO.K. Continuing with refresh ... "
+               badans=false
+               ;;
+        n|no)  echo -e "\nO.K. Exiting."
+               exit
+               ;;
+        *)     echo -e "\nPlease answer with y=yes or n=no : \c"
+      esac
+    done
+
+#--------------------- Comment out the next two lines ---------------------
+echo "This script must be customized before use.  See script for details."
+exit
+#--------------------------------------------------------------------------
 #
-#To customize this script (as 'root') on the Spare computer:
+# To customize this script (as 'root') on the Spare computer:
 #   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE COMPUTER
 #   2. Execute the commands:
 #        cd /usr/local/sbin
@@ -71,37 +134,110 @@ echo "See script for details."
 #        chown root.root refresh_spare_usr2
 #        chmod a+r,u+wx,go-wx refresh_spare_usr2
 #   3. Edit '/usr/local/sbin/refresh_spare_usr2':
-#        A. comment out the two echo commands above (add leading '#'s).
-#        B  change the 'operational' on the ssh command below to the node name
-#           (a fully qualified hostname may be needed) or IP address of the
-#           operational machine
-#        C. uncomment (delete the leading '#'s) in the last 24 commands
-#            below (#echo "Refreshing ..." ... #echo "Done. ...").
-#        D. Save the results
-#   4. Test it the first time just after the Spare computer's disk hase been rotated.
+#        A. Comment out the two commands above (add leading '#'s).
+#        B  Change the 'operational' on the TWO ssh command below to the
+#           alias, FQDN, or IP address of your operational machine
+#        C. Save the results
+#   4. Test it the first time just after the Spare computer's disk have
+#      been rotated.
 #
-#----------- Uncomment from here to the end --------------
-#echo "Refreshing spare computer disk /usr2 partition ..."
-#if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
-# echo "Can't proceed, /usr2 is not mounted"
-# exit
-#fi
-#device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
-#type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
-#fuser -k -M -m /usr2 || :
-#umount /usr2
-#UUID=$(tune2fs -l $device | grep UUID | grep -o '[^ ]*$')
-#echo "Executing \"mke2fs -F -t $type -U $UUID $device\" ..."
-#mke2fs -F -t $type -U $UUID $device
-#mount /usr2
-#echo ""
-#echo "You may be prompted for your operational machine's root password, then"
-#echo "there will be a long pause without any output unless there are errors. If"
-#echo "there are errors, please note them and report them to Ed.Himwich@nviinc.com."
-#echo "When the transfer finishes, a summary of the transfer will be printed."
-#echo "The refresh is finished when you see a line that starts: 'Done. ...',"
-#echo "and get a prompt. Please follow the directions on the 'Done. ...' line."
-#echo ""
-#ssh root@operational 'cd /usr2; tar --one-file-system -cf - .' | (cd /usr2; tar xpf - --totals)
-#echo ""
-#echo "Done. Wait until 'mdstat' does not show an active recovery and then reboot."
+    if [[ -n "$background" ]]; then
+        cat << EOF
+
+    Going to background, you should log out now or you may be logged out
+    automatically.  Don't login again to either computer until you expect the
+    'refresh_spare_usr2' to have finished.  An email with the log file will be
+    sent to 'root' when the script finishes.
+
+EOF
+        dir=/root/refresh_spare_usr2_logs
+        if [[ ! -d  "$dir" ]]; then
+           mkdir "$dir"
+        fi
+        log="$dir/$(date +"%Y.%b.%d.%H.%M.%S")".log
+        echo "Log file is $log"
+        echo ""
+        exec 1>>$log
+        exec 2>&1
+        nohup "$0" "$special" "$log" &
+        exit
+    fi
+fi
+
+echo "Refreshing spare computer disk /usr2 partition ..."
+date="$(date)"
+echo "Starting at $date"
+if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
+ echo "Can't proceed, /usr2 is not mounted"
+ exit
+fi
+
+device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
+type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
+
+if [[ -z "$subscript" ]]; then
+    cat << EOF
+
+    If you are logged out automatically, the 'refresh_spare_usr2' failed.  You
+    were probably on '/usr2' before you switched to 'root'.  Try again, but
+    'cd /tmp' before switching to 'root'.
+
+EOF
+fi
+
+fuser -k -M -m /usr2 || :
+umount /usr2
+UUID=$(tune2fs -l $device | grep UUID | grep -o '[^ ]*$')
+echo "Executing \"mke2fs -F -t $type -U $UUID $device\" ..."
+mke2fs -F -t $type -U $UUID $device
+mount /usr2
+echo "Completed \"mount /usr2\""
+echo ""
+
+if [[ -z "$subscript" ]]; then
+    if [[ -n "$pv" ]]; then
+        cat << EOF
+    You may be prompted for your operational machine's root password twice and
+    then you will see a progess meter.
+EOF
+    else
+       cat << EOF
+    You may be prompted for your operational's machines root password once and
+    then there will be a long pause without any output unless there are errors.
+EOF
+    fi
+    cat << EOF
+
+    When the transfer finishes, a summary of the transfer will be printed and
+    you will see a line that starts: 'Done. ...', and get a prompt. Please
+    follow the directions on the 'Done. ...' line.  An email will be sent to
+    'root' when the script finishes.
+
+EOF
+fi
+
+cat << EOF
+    If there are errors, please note them and report them at
+    https://github.com/nvi-inc/fsl10/issues.
+
+EOF
+
+if [[ -n "$pv" && -z "$background" ]]; then
+    size="$(ssh root@operational df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
+else
+    size=
+fi
+
+time ssh root@operational 'cd /usr2; tar --one-file-system -cf - .' | safe_pv | (cd /usr2; tar xpf - --totals)
+
+cat << EOF
+
+Done. Wait until 'mdstat' does not show an active recovery and then reboot.
+EOF
+
+if [[ -z "$subscript" ]]; then
+    echo ""
+    echo "Started at $date" | /usr/bin/mail -s "foreground refresh_spare_usr2 finished" root
+else
+    cat "$log" | /usr/bin/mail -s "background refresh_spare_usr2 finished" root
+fi

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -27,7 +27,7 @@ usage() {
 Usage: $0 [options]
 This script refreshes '/usr2' on the Spare system.
 
-Options:
+OPTIONS
  -f       Run in foreground
  -h       Help: this output
  -s       Suppress sending email
@@ -46,35 +46,28 @@ logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
 and NOT have your working directory on '/usr2'.  Make sure all other users are
 logged-out on both systems before using this script.
 
-To run the script, it is recommended to log in as 'root' on a text console or
-'ssh' into the machine using a non-'root' account, 'cd /tmp', and finally
-promote to 'root'.
+To run the script, it is recommended that you login on a text console as
+'root'.  You could also login as a non-'root' user either on a text console or
+by 'ssh' from another system.  For either approach as a non-'root' user, you
+should 'cd /tmp' and then promote to 'root'.
 
 If the '-f' option is used to refresh in foreground and you promoted to 'root',
 then the original session must not have its working directory on '/usr2', nor
 be an X session opened by an account that has its home directory on '/usr2'.  A
 refresh will work for both of those cases without the '-f' option, but you will
-be abruptly logged out when the refresh starts.
-
-This script must be customized before it is used.  Directions for that are
-embedded in the script.
-
-WARNING: It may not be possible to setup the script to login into the
-         Operational system with 'ssh' keys.  It may still be possible to
-         connect with a password; in which case, the script will only work if
-         used with '-f', foreground mode.  Using the CIS hardening approach may
-         be a usable alternative if there are obstacles with using 'ssh' keys
-         to log into the 'root' account.  See the comments in the script for
-         more information,
-
-For foreground refreshes, a progress bar with an ETA will be displayed if the
-'pv' package is installed.
+be automatically logged out while the refresh continues in background.
 
 The script creates a log file of what happened during the refresh operation in
 '/root/refresh_spare_usr2_logs' directory. The log file name includes a
 time-stamp of when the refresh was started.
 
 An email is sent to 'root' with the log file contents when the script finishes.
+
+The script has two modes, background, which is the default, and foreground
+using the '-f' option.
+
+For foreground refreshes, a progress bar with an ETA will be displayed if the
+'pv' package is installed.
 
 The refresh is normally performed in background.  When the script is first
 installed on a system, it is recommended to run it in foreground with the '-f'
@@ -92,6 +85,24 @@ or an email, before performing the finishing up steps: checking that 'mdstat'
 does not show an active recovery and then rebooting.  Those finishing up steps
 are also need for foreground mode, but it should be apparent from the screen
 output when the refresh has finished.
+
+The script may take up to three times longer to complete if both the
+Operational and Spare systems are refreshing their secondary disks concurrently
+than when the systems are quiescent.
+
+INSTALLATION
+
+This script must be customized before it is used.  Directions for that are
+embedded in the script.
+
+It may not be possible to setup the script to login into the Operational system
+with 'ssh' keys.  If not, it may still be possible to connect with a password;
+in which case, the script will only work if used with '-f', foreground mode.
+Using the CIS hardening approach may be a usable alternative if there are
+obstacles with using 'ssh' keys to log into the 'root' account.  See the
+comments in the script for more information.
+
+CRITICAL PHASE
 
 The critical phase of operation of the script occurs between the printing of
 

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.3.1 - March 2021
+Version 1.3.2 - September 2021
 
 :experimental:
 :toc:
@@ -645,122 +645,6 @@ auth required pam_tally2.so deny=5
 Small integer values (20 or less) should not be a signficant risk with
 long and complicated passwords and a lock-out of several minutes.
 
-=== refresh_spare_usr2 with CIS hardening setup
-
-IMPORTANT: Please read the
-<<raid.adoc#_refresh_spare_usr2,refresh_spare_usr2>> section in the
-'RAID Notes for FSL10' document for important information on the
-*refresh_spare_usr2* script.
-
-NOTE: Despite what the script says, it is possible to run the script
-by using *su* or *sudo*/*root_account* from a non-root account as long
- as there is no activity involving */usr2* and
-the user's current directory is not on */usr2*.
-
-For a user other than *root* to use the script, _after_ they have made
-sure they are not currently on */usr2* (*cd*-ing away if necessary),
-     they should use the command 
-
-....
-sudo refresh_spare_usr2
-....
-
-The remainder of this sub-section describes the steps need to enable
-use of the script with CIS hardening. The possibility of running it as
-*root* or from a different account is allowed for the instructions.
-
-==== On operational computer
-
-===== Use visudo to add:
-
-....
-spare          ALL=(ALL) NOPASSWD: /usr/local/sbin/send_usr2
-....
-
-===== Create file:
-
-./usr/local/sbin/send_usr2
-[source,bash]
-----
-#!/bin/bash
-cd /usr2; tar --one-file-system -cf - .
-----
-
-Permissions: *rwxr--r--*, ownership *root:root*.
-
-===== Create spare account:
-
-NOTE: The user's home directory is on */home* (by default), not */usr2*.
-
-NOTE: The *UID* and *GID* values of *2000* are chosen to make it
-easier to keep the values in sync for users on both machines. In other
-words, it is not necessary to worry about jumping over a low value on
-the *spare* machine when values are assigned sequentially, as is the
-default.  If you think you might have more than 1000 users or groups,
-you might want to increase the values for the *spare* account.
-
-----
-addgroup spare --gid 2000
-adduser spare --uid 2000 --gid 2000
-----
-
-==== On spare computer
-
-===== In refresh_spare_usr2, customize as usual and change:
-
-....
-ssh root@operational 'cd /usr2; tar --one-file-system -cf - .' | (cd /usr2; tar xpf - --totals)
-....
-
-to
-....
-ssh spare@operational -o LogLevel=ERROR sudo send_usr2 | (cd /usr2; tar xpf - --totals)
-....
-
-where *operational* is the name or IP of your operational computer.
-
-===== Create and copy a key for root
-
-If *root* already has one, you only need the second command below to copy it to the *spare* account:
-
-NOTE: It is recommended to not set a passphrase.
-
-----
-ssh-keygen
-ssh-copy-id spare@operational
-----
-
-where *operational* is the name or IP of your operational computer.
-
-===== For a different user than root to run the script
-
-IMPORTANT: They must not have their current directory on */usr2* when they run the script.
-
-Use *visudo* to add
-
-....
-%operators         ALL=(ALL) /usr/local/sbin/refresh_spare_usr2
-....
-
-It could be limited to a specific user (but not *oper* or *prog*)
-by replacing *%operators* with the user account name.
-
-==== On operational computer
-
-===== Lock out spare account from normal login (but must have a shell):
-
-This will disable password login for this user:
-
-----
-usermod -L spare
-----
-
-===== Disable password aging and inactivity time-out for this account:
-
-----
-chage -I -1 -M 99999 spare
-----
-
 === Setting hostname alias
 
 These steps set a more user friendly alias for the computers of the
@@ -833,45 +717,213 @@ to confirm connecting. Finally, logout of the `spare` account on
 
 .. In the statement setting `PS1` in the `case` block that sets the `xterm` window title, change the use of `\h` to `$hostalias`.
 
+=== Installing refresh_spare_usr2 with CIS hardening
+
+NOTE: This subsection follows the FS manual font conventions.
+
+IMPORTANT: Please read the
+<<raid.adoc#_refresh_spare_usr2,refresh_spare_usr2>> section of the
+<<raid.adoc#,RAID Notes for FSL10>> document for important information
+on the __refresh_spare_usr2__ script.
+
+This sub-section describes the steps needed to enable use of the
+_refresh_spare_usr2_ script with CIS hardening.
+
+. On the _operational_ system:
+
+.. Use _visudo_ to add:
+
++
+
+....
+spare          ALL=(ALL) NOPASSWD: /usr/local/sbin/send_usr2
+....
+
+.. Create file:
+
++
+
+./usr/local/sbin/send_usr2
+[source,bash]
+----
+#!/bin/bash
+cd /usr2; tar --one-file-system -cf - .
+----
+
++
+
+Permissions: `rwxr--r--`, ownership `root:root`.
+
+.. Create _spare_ account:
+
++
+
+NOTE: The user's home directory is on _/home_ (by default), not
+_/usr2_.
+
++
+
+NOTE: The UID and GID values of `2000` are chosen to make it easier to
+keep the values in sync for users on both systems. In other words, it
+is not necessary to worry about jumping over a low value on the
+_spare_ system when values are assigned sequentially, as is the
+default. If you think you might have more than 1000 users or groups,
+you might want to increase the values for the _spare_ account.
+
++
+
+----
+addgroup spare --gid 2000
+adduser spare --uid 2000 --gid 2000
+----
+
++
+
+. On the _spare_ system
+
+.. Customize _refresh_spare_usr2_
+
+
++
+
+The uncustomized script is provided in
+_/root/fsl10/RAID/refresh_spare_usr2_. Follow the directions in the
+comments, being sure to _uncomment_ the two lines for CIS hardened
+systems. Their commented out form is:
+
++
+
+....
+#remote_user=spare
+#remote_command='sudo send_usr2'
+....
+
+.. Create and copy a key for _root_
+
++
+
+If _root_ already has one, you only need the second command below to
+copy it to the _spare_ account:
+
++
+
+NOTE: It is recommended to not set a passphrase.
+
++
+
+[subs="+quotes"]
+----
+ssh-keygen
+ssh-copy-id spare@_operational_
+----
+
++
+
+where `_operational_` is the alias, name, or IP of your _operational_
+system.
+
+.. Enable _sudo_ to run the script
+
++
+
+Use _visudo_ to add
+
++
+
+....
+%operators         ALL=(ALL) /usr/local/sbin/refresh_spare_usr2
+....
+
++
+
++
+
+It could be limited to a specific user (but not _oper_ or _prog_)
+by replacing `%operators` with the user account name.
+
+. On the _operational_ system
+
+.. Lock out spare account from normal login (but it must have a
+shell). This will disable password login, but not _ssh_ login with
+keys, for this user:
+
+
++
+
+----
+usermod -L spare
+----
+
+.. Disable password aging and inactivity time-out for this account:
+
++
+
++
+
+----
+chage -I -1 -M 99999 spare
+----
+
 == Using refresh_spare_usr2 with CIS hardening
 
-NOTE: The purpose of the `script` command below is to record the
-output to help verify success afterwards in case the screen output is
-no longer available when it is checked for. It can also be helpful for
-diagnosing what went wrong if there was a problem.
+NOTE: This section follows the FS manual font conventions.
 
 . As part of a monthly backup, you would usually start a disk rotation
-on both the *operational* and *spare* computers first. Once both
-computers are recovering, you should log out of both machines.
+on both the _operational_ and _spare_ systems first. Once both
+systems are recovering, you should log out of both systems.
 
 +
 
 IMPORTANT: Before proceeding, make sure that no one is logged into
-either computer and that no processes are running on */usr2* on either
-machine, particularly the FS.
+either system and that no processes are running on _/usr2_ on either
+system, particularly the FS.
 
-. Login on the *spare* computer with *ssh*, or on a local virtual
-console text terminal, using an AUID account
+. Login to the _spare_ system with an AUID account on a local virtual
+console text terminal or from another system (not the _operational_
+system) using _ssh_.
+
 
 +
 
-IMPORTANT: If you logged in using *ssh* do not open an *xterm* to work
+IMPORTANT: If you logged in using _ssh_ do not open an _xterm_ to work
 in. Instead work in the window where you logged in.
 
 . Execute:
 +
     cd /tmp
-    script refresh.txt
-    time sudo refresh_spare_usr2; exit
+    sudo refresh_spare_usr2
 +
-Answer the question `y` if it is safe to proceed.
-. Check to see that it finished with no problems.
+Answer the question `*y*` if it is safe to proceed.
+
+. Log out of the system, if you weren't logged out automatically.
+
+. Check to see that it finished with no problems before logging in
+again on either system.
+
 +
-If the output of the script is no longer on the display, you can
-inspect */tmp/refresh.txt* (until the next reboot) to determine if there was a problem. You
-may need to login again to do this.
+
+An email will be sent to _root_ when the refresh finishes. If your
+email to _root_ is being forwarded to a mailbox off the system, you
+can use receipt of that message (and that it shows no errors) as the
+indication that it finished successfully.
+
++
+
+If emails to _root_ are _not_ being forwarded off the system and you
+_can_ login as _root_ on a text console, you can check _root_'s email
+for the message.
+
++
+
+Alternatively, you can use the time it took previous refreshes to
+finish to estimate how log this one may take. You can examine the logs
+(before starting the refresh) in _/root/refresh_spare_usr2_logs_ to
+see how long previous refreshes took. Typically a new refresh will
+take a little longer than the most recent previous refresh. You can
+check the log for the current refresh after at least that much time
+has elapsed.
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can
 wait until the recovery is complete. The only requirement is to reboot
-before the FS is run again on the *spare* computer.
+before the FS is run again on the _spare_ system.

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.3.2 - September 2021
+Version 1.4.0 - September 2021
 
 :experimental:
 :toc:
@@ -802,7 +802,7 @@ systems. Their commented out form is:
 
 +
 
-If _root_ already has one, you only need the second command below to
+If _root_ already has a key, you only need the second command below to
 copy it to the _spare_ account:
 
 +

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -897,8 +897,14 @@ Answer the question `*y*` if it is safe to proceed.
 
 . Log out of the system, if you weren't logged out automatically.
 
-. Check to see that it finished with no problems before logging in
-again on either system.
+. Wait until the script has finished before resuming other activities
+on the systems.
+
++
+
+CAUTION: Generally speaking, it is best to _not_ login to either the
+_spare_ or _operational_ system while the script is running, but see
+the <<note,NOTE>> below for more information.
 
 +
 
@@ -921,7 +927,38 @@ finish to estimate how log this one may take. You can examine the logs
 see how long previous refreshes took. Typically a new refresh will
 take a little longer than the most recent previous refresh. You can
 check the log for the current refresh after at least that much time
-has elapsed.
+has elapsed to verify that it has finished.
+
++
+
+[[note]]
+[NOTE]
+====
+
+Do not login to an account on the _spare_ system with a home directory
+on the _/usr2_ partition (logging in as _root_ on a text console is
+okay) or otherwise access that partition during the refresh.
+
+It is possible to use the _operational_ system during the refresh if
+necessary, but this should be avoided if possible and activity on the
+_/usr2_ partition should be as limited as possible.  You should not
+expect any changes on the _operational_ system _/usr2_ that occur
+after the refresh starts to be propagated to the _spare_ system.  If
+any files on the _operational_ system _/usr2_ are deleted from it
+before they could be copied, there may be error messages like:
+
+[subs="+quotes"]
+....
+tar: _file_: Cannot stat: No such file or directory
+....
+
+for those ``_file_``s and a final summary error message:
+
+  tar: Exiting with failure status due to previous errors
+
+but without other errors the refresh should still generally succeed.
+
+====
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.3.7 - March 2021
+Version 1.4.0 - September 2021
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.3.7 - January 2021
+Version 1.3.8 - September 2021
 
 :sectnums:
 :experimental:
@@ -639,109 +639,133 @@ little slow.
 
 === refresh_spare_usr2
 
+NOTE: This subsection follows the FS manual font conventions.
+
 This script is not part of RAID operations per se, but is included in
-this document for completeness. In a two computer configuration
-(*operational* and *spare*), it is used to make a copy of the
-*operational* computer's */usr2* partition on the *spare* computer.
+this document for completeness. In a two system configuration
+(_operational_ and _spare_), it is used to make a copy of the
+_operational_ system's _/usr2_ partition on the _spare_ system.
 Normally this partition holds all the operational FS programs and
-data. The script can be found in */root/fsl10/RAID*.  Full
+data. The script can be found in _/root/fsl10/RAID_. Full
 instructions for its installation are included in the script. The
 script will give a warning about its use and prompt for permission to
 proceed when it it is run.
 
-WARNING: It should installed on the *spare* computer _only_.
+IMPORTANT: It should be installed on the _spare_ system _only_.
 
-WARNING: When this script is run, neither computer should have anyone logged in
-with a home directory on */usr2* nor should there be any activity occurring that
-will affect */usr2*.
+WARNING: When this script is run, neither system should have anyone
+logged in with a home directory on _/usr2_ nor should there be any
+activity occurring that will affect _/usr2_.
 
-NOTE: Despite what the script says, it is possible to run the script
-by using *su* or *sudo* from a non-root account as long as there is no
-activity involving */usr2* and the user's current directory is not on
-*/usr2*. For the latter issue, *cd*-ing to */tmp* is a reasonable
-choice. If after entering `y` to proceed, you are unceremoniously
-logged out, it probably means you still had your current directory
-somewhere on */usr2*. In this case, no harm was done. You can try
-re-running the script, but this time please be sure to *cd* off
-*/usr2* first.
-
-IMPORTANT: For this script to work usefully, the *operational* and
-*spare* computers should have the same set-up including particularly the
+WARNING: For this script to work usefully, the _operational_ and
+_spare_ systems should have the same set-up including particularly the
 same user accounts with same UIDs and GIDs in parallel for all
-accounts, particularly for those that have home directories on */usr2*,
-  as well as other OS set-up information the FS may depends such as
-  */etc/hosts* and */etc/ntp.conf*.
+accounts, particularly for those that have home directories on
+_/usr2_, as well as other OS set-up information the FS may depend ons
+such as _/etc/hosts_ and _/etc/ntp.conf_.
 
-IMPORTANT: It is recommended that the script be used (including for initial testing)
-  immediately after a disk rotation to provide the ample opportunities
-  for recovery if there is a problem. In particular, for initial
-  testing the procedure in the <<Recoverable testing>>
-  section should be used.
+IMPORTANT: It is recommended that the script be used (including for
+initial testing) immediately after a disk rotation to provide the
+ample opportunities for recovery if there is a problem. In particular,
+for initial testing the procedure in the <<Recoverable testing>>
+section above should be used.
 
-TIP: It is possible to recover fairly easily, using the script as a guide,
-from most operations performed by the script if they are accidentally
-terminated with a kbd:[Ctrl+C]. A significant exception to this is the
-*mke2fs* command. For this reason, the script displays the command to
-the terminal to allow the user to cut-and-paste the command to
-re-execute it, in case that is ever needed.
+TIP: If the script is accidentally terminated with a kbd:[Ctrl+C] (in
+foreground) or otherwise aborted, it is usually possible to recover by
+rerunning the script. A significant exception is if the abort occurs
+during the _mke2fs_ command. For this reason, the script prints that
+command to the log (and the terminal, when run in foreground) to allow
+the user to copy-and-paste the command to re-execute it, in case that
+is ever needed. Steps for recovery from an abort, which are fairly
+easy, are discussed in the `CRITICAL PHASE` section of the
+`*refresh_spare_usr2{nbsp}-h*` output.
 
 [TIP]
 ====
-A recommended monthly back strategy is to do a disk rotation on
-both computers. Once the RAIDs on both computers are "recovering" you
-can log-out of both computers and then login into the *spare* computer
-again to start *refresh_spare_usr2*.
 
-The recovery of the RAIDs will
-increase the amount of time that the *refresh_spare_usr2* takes to
-complete.  It has been observed in some cases to approximately double
-the time required.
+A recommended monthly backup strategy is to do a disk rotation on both
+systems. Once the RAIDs on both systems are _recovering_ you can
+log-out of both systems and then login into the _spare_ system again
+to start _refresh_spare_usr2_.
 
-Once *refresh_spare_usr2* completes, it is safe to reboot, even if
-a recovery is still ongoing. The only requirement is to
-reboot the *spare* computer before the FS is run on it again.
+The recovery of the RAIDs will increase the amount of time that the
+_refresh_spare_usr2_ takes to complete. It has been observed in some
+cases to approximately double the time required.
 
-A feature of this approach is that will make the *spare* computer
-shelf disk a deeper back-up than the *spare* computer RAID disks.
+Once _refresh_spare_usr2_ completes, it is safe to reboot, even if a
+recovery is still ongoing. The only requirement is to reboot the
+_spare_ system before the FS is run on it again.
+
+A feature of this approach is that will make the _spare_ system shelf
+disk a deeper back-up than the _spare_ system RAID disks.
 
 ====
 
 ==== Using refresh_spare_usr2
 
-NOTE: The purpose of the `script` command below is to record the
-output to help verify success afterwards in case the screen output is
-no longer available when it is checked for. It can also be helpful for
-diagnosing what went wrong if there was a problem.
-
 . As part of a monthly backup, you would usually start a disk rotation
-on both the *operational* and *spare* computers first. Once both
-computers are recovering, you should log out of both machines.
+on both the _operational_ and _spare_ systems first. Once both systems
+are recovering, you should log out of both systems.
 
 +
 
 IMPORTANT: Before proceeding, make sure that no one is logged into
-either computer and that no processes are running on */usr2* on either
-machine, particularly the FS.
+either system and that no processes are running on _/usr2_ on either
+system, particularly the FS.
 
-. Login on the *spare* computer on a local virtual console text terminal as *root*.
+. Login on the _spare_ system on a local virtual console text terminal
+as _root_.
+
++
+
+An alternative is to login as a non-_root_ user either on a text
+console or by _ssh_ from another system. In this case, you should
+`*cd{nbsp}/tmp*` and then either promote to _root_ using _su_ or run
+the script with _sudo_.
+
 
 . Execute:
-+
-    script refresh.txt
-    time refresh_spare_usr2; exit
-+
-Answer the question `y` if it is safe to proceed.
-. Check to see that it finished with no problems.
+
+refresh_spare_usr2
+
 +
 
-If the output of the script is no longer on the display, you can
-inspect */refresh.txt* to determine if there was a problem. You may
-need to login again to do this.
+Answer the question `*y*` if it is safe to proceed.
+
++
+
+. Log out of the system, if you weren't logged out automatically.
+
+. Check to see that it finished with no problems before logging in
+again on either system.
+
++
+
+An email will be sent to _root_ when the refresh finishes. If your
+email to _root_ is being forwarded to a mailbox off the system, you
+can use receipt of that message (and that it shows no errors) as the
+indication that it finished successfully.
+
++
+
+If emails to _root_ are _not_ being forwarded off the system and you
+_can_ login as _root_ on a text console, you can check _root_'s email
+for the message.
+
++
+
+Alternatively, you can use the time it took previous refreshes to
+finish to estimate how log this one may take. You can examine the logs
+(before starting the refresh) in _/root/refresh_spare_usr2_logs_ to
+see how long previous refreshes took. Typically a new refresh will
+take a little longer than the most recent previous refresh. You can
+check the log for the current refresh after at least that much time
+has elapsed.
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can
 wait until the recovery is complete. The only requirement is to reboot
-before the FS is run again on the *spare* computer.
+before the FS is run again on the _spare_ system.
 
 == Multiple computer set-up
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.3.8 - September 2021
+Version 1.4.0 - September 2021
 
 :sectnums:
 :experimental:
@@ -719,9 +719,9 @@ as _root_.
 +
 
 An alternative is to login as a non-_root_ user either on a text
-console or by _ssh_ from another system. In this case, you should
-`*cd{nbsp}/tmp*` and then either promote to _root_ using _su_ or run
-the script with _sudo_.
+console or by _ssh_ from another system (not the _operational_
+system). In this case, you should `*cd{nbsp}/tmp*` and then either
+promote to _root_ using _su_ or run the script with _sudo_.
 
 
 . Execute:

--- a/raid.adoc
+++ b/raid.adoc
@@ -696,8 +696,8 @@ Once _refresh_spare_usr2_ completes, it is safe to reboot, even if a
 recovery is still ongoing. The only requirement is to reboot the
 _spare_ system before the FS is run on it again.
 
-A feature of this approach is that will make the _spare_ system shelf
-disk a deeper back-up than the _spare_ system RAID disks.
+A feature of this approach is that it will make the _spare_ system
+shelf disk a deeper back-up than the _spare_ system RAID disks.
 
 ====
 
@@ -726,7 +726,7 @@ the script with _sudo_.
 
 . Execute:
 
-refresh_spare_usr2
+  refresh_spare_usr2
 
 +
 
@@ -736,8 +736,14 @@ Answer the question `*y*` if it is safe to proceed.
 
 . Log out of the system, if you weren't logged out automatically.
 
-. Check to see that it finished with no problems before logging in
-again on either system.
+. Wait until the script has finished before resuming other activities
+on the systems.
+
++
+
+CAUTION: Generally speaking, it is best to _not_ login to either the
+_spare_ or _operational_ system while the script is running, but see
+the <<note,NOTE>> below for more information.
 
 +
 
@@ -760,7 +766,38 @@ finish to estimate how log this one may take. You can examine the logs
 see how long previous refreshes took. Typically a new refresh will
 take a little longer than the most recent previous refresh. You can
 check the log for the current refresh after at least that much time
-has elapsed.
+has elapsed to verify that it has finished.
+
++
+
+[[note]]
+[NOTE]
+====
+
+Do not login to an account on the _spare_ system with a home directory
+on the _/usr2_ partition (logging in as _root_ on a text console is
+okay) or otherwise access that partition during the refresh.
+
+It is possible to use the _operational_ system during the refresh if
+necessary, but this should be avoided if possible and activity on the
+_/usr2_ partition should be as limited as possible.  You should not
+expect any changes on the _operational_ system _/usr2_ that occur
+after the refresh starts to be propagated to the _spare_ system.  If
+any files on the _operational_ system _/usr2_ are deleted from it
+before they could be copied, there may be error messages like:
+
+[subs="+quotes"]
+....
+tar: _file_: Cannot stat: No such file or directory
+....
+
+for those ``_file_``s and a final summary error message:
+
+  tar: Exiting with failure status due to previous errors
+
+but without other errors the refresh should still generally succeed.
+
+====
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can


### PR DESCRIPTION
I am putting just the script out for now without a document update. I would like to get to a nearly final version of the feaures before putting the effort in on the documents.

Summary of changes:

- Add a background mode with a log file, which is now the default.
- Use _pv_ for a progress meter in foreground mode.
- Send email message when done.
- Trap or explain all cases where being on _/usr2_ causes an issue.
- Reformat and reorganize messages using here document.
- Bring message content up to date.
- Add `Completed ...` message to mark end of executing critical code.
- Indent script written messages during refresh to make them standout.
- Add date/time commands to record when it started and how long it took.
- Simplify installation by not having to uncomment code.

The old script was very cumbersome in the CIS hardened environment, which it was never designed for. I prettied (not the original word I was going to use) it up to make it easier to use, more self explanatory, make a record of what happened, provide a progress meter, and brought the messages up to date. It is so different than the previous version, I think a `diff` is probably not very useful. It is however still built around Jon's original code for this task. I borrowed some ideas from Dave and web searches. Hopefully, it will be more usable for the non-CIS environment as well.

An advantage of the background mode is that the user can start it running, log-out, and walk away. An email is sent when it finishes. There is a saved copy of the log on disk. The thought is that the foreground mode might be used once to make sure it is working and see how long it takes, then background mode would be used after that.

 Some items to consider:

- The only way I was able to make the background mode work was to rerun the script with _nohup_ using a special argument to trigger doing the actual work. That seems okay. There are some gymnastics to avoid some warnings for I/O redirection from _nohup_. There may be better ways to do these things.
- It would be possible to have a log file for foreground use, but it seems _pv_ detects that it is not directly connected to a terminal and refuses to show the progress meter. I didn't want to give up having a progress meter for foreground mode.
- I resisted the temptation to add an option to remove the preamble messages and the confirmation to proceed. The script is used infrequently enough that I thought it was better to keep the operator in the loop. I ran it so many times for testing, such an option would have been useful.

Other possible improvements:

- Colorize the script's messages during a foreground refresh to make them standout more.
- Add an option to disable email.
- Other suggestions?