### PR TITLE
Change refresh_spare_usr2 to use rsync

### DIFF
--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -24,38 +24,34 @@ set -e
 usage() {
     cat << EOF
 
+This script refreshes the contents of the Spare system '/usr2' partition if you
+have both Operational and Spare systems.  Rebooting afterwards is recommended.
+
+IMPORTANT: This script will overwrite everything on the '/usr2' partition of
+           the system it is run on.  Use it only on the Spare system.
+
 Usage: $0 [options]
-This script refreshes '/usr2' on the Spare system.
 
 OPTIONS
- -f       Run in foreground
- -h       Help: this output
- -s       Suppress sending email
- -y       Yes: proceed without prompting for confirmation
 
-This is a script to refresh the contents of the Spare system '/usr2' partition
-if you have both Operational and Spare systems.
+ -F       run in Foreground
+ -h       help: this output
+ -i       ignore file modifications times, forcing ALL files to be updated
+ -I       Initialize local '/usr2' and then copy ALL files and directories
+ -N       Nothing: this option is used internally and has no effect
+ -s       suppress sending email
+ -Y       Yes: proceed without prompting for confirmation
 
-CAUTION: This script will automatically overwrite everything on the '/usr2'
-         partition of the system it is run on.  Use it only on the Spare
-         system.  It will stop any processes that are using the '/usr2'
-         partition.  Rebooting afterwards is recommended.
+The '-i' option should only be rarely needed.  It is recommended to NOT use
+uppercase options except in special circumstances.
+
+DESCRIPTION
 
 This script must be executed by 'root' on the Spare system.  You must be
-logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'
-and NOT have your working directory on '/usr2'.  Make sure all other users are
-logged-out on both systems before using this script.
-
-To run the script, it is recommended that you login on a text console as
-'root'.  You could also login as a non-'root' user either on a text console or
-by 'ssh' from another system.  For either approach as a non-'root' user, you
-should 'cd /tmp' and then promote to 'root'.
-
-If the '-f' option is used to refresh in foreground and you promoted to 'root',
-then the original session must not have its working directory on '/usr2', nor
-be an X session opened by an account that has its home directory on '/usr2'.  A
-refresh will work for both of those cases without the '-f' option, but you will
-be automatically logged out while the refresh continues in background.
+logged-in as 'root' or promote to 'root' using 'su' or 'sudo'/'root_account'.
+It is best if all other sessions are logged-out of both systems and there be no
+activity on either system's '/usr2'.  See the 'USING THE INITIALIZATION OPTION'
+section below for restrictions that apply when the '-I' option is used.
 
 The script creates a log file of what happened during the refresh operation in
 '/root/refresh_spare_usr2_logs' directory. The log file name includes a
@@ -63,22 +59,19 @@ time-stamp of when the refresh was started.
 
 An email is sent to 'root' with the log file contents when the script finishes.
 
+If the script is aborted while it is running, it is usually possible to recover
+by simply rerunning it.  An important exception to this when using the '-I'
+option is described, with recovery steps, in the CRITICAL PHASE section below.
+
+The script may take up to three times longer to complete if both the
+Operational and Spare systems are refreshing their secondary disks than when
+the systems are quiescent.
+
+MODES
+
 The script has two modes, background, which is the default, and foreground
-using the '-f' option.
-
-For foreground refreshes, a progress bar with an ETA will be displayed if the
-'pv' package is installed.
-
-The refresh is normally performed in background.  When the script is first
-installed on a system, it is recommended to run it in foreground with the '-f'
-option to verify that it is working and get an idea how long the transfer will
-take.  It usually only takes a few minutes for newly installed systems.  The
-time required will gradually increase as '/usr2' on the Operational system
-accumulates more data.  The actual transfer time will be shown on the screen in
-foreground mode.  For either mode, it can also be found in the log file on
-disk, which is typically emailed to 'root' as well, when the script finishes.
-It is recommended to check and be aware of how how long transfers take, so you
-know about how long to expect the next transfer to take.
+using the '-f' option.  For background refreshes, the overall 'rsync' transfer
+statistics and overall time required  are included in the log file.
 
 For background refreshes, verify that it has finished, either from the log file
 or an email, before performing the finishing up steps: checking that 'mdstat'
@@ -86,55 +79,79 @@ does not show an active recovery and then rebooting.  Those finishing up steps
 are also need for foreground mode, but it should be apparent from the screen
 output when the refresh has finished.
 
-The script may take up to three times longer to complete if both the
-Operational and Spare systems are refreshing their secondary disks concurrently
-than when the systems are quiescent.
+For foreground refreshes, a progress report of the number of files transferred,
+elapsed time, and the rate of files be transferred is displayed if the 'pv'
+package is installed.  The number of files and the rate may appear to pause
+when very larges files are being transferred.  There is no ETA or percentage
+completion available.  The overall transfer statistics are not shown, but the
+overall time is still shown.
 
 USING THE SYSTEMS WHILE THE SCRIPT IS RUNNING
 
-Do not login to an account on the spare system with a home directory on the
-'/usr2' partition (logging in as 'root' on a text console is okay) or otherwise
-access that partition during the refresh.
+It is best to NOT login to an account on the spare system with a home directory
+on the '/usr2' partition (logging in as 'root' on a text console is okay) or
+otherwise access that partition during the refresh.  Accounts with home
+directories on the spare system '/usr2' partition may not be fully configured
+until after the refresh completes.
 
 It is possible to use the operational system during the refresh if necessary,
 but this should be avoided if possible and activity on the '/usr2' partition
 should be as limited as possible.  You should not expect any changes on the
 operational system '/usr2' that occur after the refresh starts to be propagated
-to the spare system.  If any files on the operational system '/usr2' are
-deleted from it before they could be copied, there may be error messages like:
+to the spare system.  There may be some warnings that files cannot be found on
+the operational system if they are deleted before they are transferred.
 
-  tar: ...: Cannot stat: No such file or directory
+USING THE INITIALIZATION OPTION
 
-for those files (named in place of the '...') and a final summary error
-message:
+When using the '-I' option, it is recommended that you login on a text console
+as 'root'.  Alternatively, you could login as a non-'root' user either on a
+console or by 'ssh' from another system (preferably not the operational
+system).  For either approach as a non-'root' user, you must make sure your
+working directory is not on '/usr2', for example by using 'cd /tmp', before
+running the script.  It is best to get off '/usr2' before promoting to 'root'.
 
-  tar: Exiting with failure status due to previous errors
+WARNING: All processes that are using the '/usr2' partition will be terminated.
 
-but without other errors the refresh should still generally succeed.
+In addition, if you use the -f' option to refresh in foreground, you must NOT
+have originally logged into an X session of an account that has its home
+directory on '/usr2' NOR have any ancestor (parent) process of your shell with
+its working directory on '/usr2' (if you logged in with 'ssh', this includes
+NOT working in an 'xterm' that you started before moving your working directory
+off '/usr2').  A refresh will work for both of these cases without the '-f'
+option, but you will be automatically logged out while the refresh continues in
+background.
+
+Please see the CRITICAL PHASE section below information on recovering from the
+script being aborted while using the '-I' option.
 
 CRITICAL PHASE
 
-The critical phase of operation of the script occurs between the printing of
+In many cases, if the script is unexpectedly aborted when using the '-I'
+option, if it is possible to recover simply by rerunning the script.  An
+important exception this is if the abort occurs in the 'critical phase'.
+
+The critical phase of operation occurs between the printing of
 
     Starting critical phase. Executing "umount /usr2" ...
 
 and
 
-    ... completed "mount /usr2". The critical phase is finished.
+    ... completed "mount /usr2". The critical phase has finished.
 
 If the script is interrupted or otherwise fails between these commands, it will
 usually be necessary to take corrective action.  This normally consists of
 re-executing (using copy-and-paste) the contents (everything from between the
-double quotes, typically a long string, it will probably overwrap your terminal
-width) of the output line
+double quotes, typically a long string that will probably overwrap your
+terminal width) of the output line
 
     Executing "mke2fs -F -t ..."
 
 That line is printed during the critical phase and can be found in the log
 file, or if the '-f' option was used, may be visible on the screen.  If the
-re-execution of 'mke2fs ...' fails because '/usr2' is mounted, you will need to
-execute 'umount /usr2' before trying again.  After 'mke2fs' has been
-re-executed successfully, execute 'mount /usr2' and try the script again.
+re-execution of 'mke2fs -F -t ...' fails because '/usr2' is mounted, you will
+need to execute 'umount /usr2' before trying again.  After 'mke2fs' has been
+re-executed successfully, you can execute 'mount /usr2' and try the script
+again.
 
 INSTALLATION
 
@@ -145,8 +162,8 @@ It may not be possible to setup the script to login into the Operational system
 with 'ssh' keys.  If not, it may still be possible to connect with a password;
 in which case, the script will only work if used with '-f', foreground mode.
 Using the CIS hardening approach may be a usable alternative if there are
-obstacles with using 'ssh' keys to log into the 'root' account.  See the
-comments in the script for more information.
+obstacles to logging into the 'root' account remotely, with or without using
+'ssh' keys.  See the comments in the script for more information.
 
 EOF
 }
@@ -160,31 +177,37 @@ else
 fi
 
 safe_pv() {
-    if [[ -z "$pv" || -n "$background" ]]; then
-        cat
-    elif [[ ! "$size" =~ ^[1-9][0-9]*k$ ]]; then
-# defensive
-        $pv -W 2>/dev/tty
-    else
-        $pv -W -s "$size" 2>/dev/tty
+    if [[ -n "$pv" ]]; then
+        $pv -Wlbrt 2>/dev/tty
     fi
 }
+
 background=1
 proceed=
 send_email=1
-while getopts fhsy opt; do
+initialize=
+ignore=
+while getopts FhiINsY opt; do
     case $opt in
-        f)
+        F)
             background=
             ;;
         h)
             usage
             exit
             ;;
+        i)
+            ignore=1
+            ;;
+        I)
+            initialize=1
+            ;;
+        N)
+            ;;
         s)
             send_email=
             ;;
-        y)
+        Y)
             proceed=1
             ;;
         *)
@@ -199,7 +222,7 @@ while getopts fhsy opt; do
 done
 shift $((OPTIND - 1))
 
-special=special_arg_to_run_subscript
+special=special_arg_to_run_sub-script
 subscript=
 if [[ "$1" = "$special" ]]; then
   subscript=1
@@ -209,7 +232,7 @@ log=$2
 
 if [[ -z "$subscript" ]]; then
 
-    if [[ "$PWD/" =~ ^/usr2/ ]]; then
+    if [[ -n "$initialize" && "$PWD/" =~ ^/usr2/ ]]; then
        echo "You are on '/usr2'. Try again, but 'cd /tmp' first."
        exit 1
     fi
@@ -223,8 +246,8 @@ if [[ -z "$subscript" ]]; then
 
         cat << EOF
 
-    IMPORTANT: No one else should be logged into this system and no one should
-               be logged into the Operational system.
+    IMPORTANT: It is best if no other sessions are logged in on this system and
+               no sessions should be logged in on the Operational system.
 
 EOF
 
@@ -271,8 +294,11 @@ exit 1
 #      password login; in which case, only '-f', foreground mode, will be
 #      usable.  The CIS hardening approach may be a useful alternative if there
 #      are problems with using 'ssh' keys to log into the 'root' account.  For
-#      more information, see:
-#      https://nvi-inc.github.io/fsl10/cis-setup.html#_refresh_spare_usr2_with_cis_hardening_setup
+#      more information, see the 'Installing refresh_spare_usr2 with CIS
+#      hardening' subsection of the 'CIS Hardending for FSL10 document'.  You
+#      may find the description of how to modify that approach to use the
+#      'root' account in the 'refresh_spare_usr2' subsection of the 'RAID Notes
+#      for FSL10' useful.
 #   5. Test it the first time just after the Spare system's disk has been
 #      rotated.
 #
@@ -283,6 +309,21 @@ exit 1
        mkdir "$dir"
     fi
     log="$dir/$(date +"%Y.%b.%d.%H.%M.%S")".log
+
+#set most options for sub-script
+    options=N
+    if [[ -z "$send_email" ]]; then
+         options="${options}s"
+    fi
+    if [[ -n "$ignore" ]]; then
+        options="${options}i"
+    fi
+    if [[ -n "$initialize" ]]; then
+        options="${options}I"
+    fi
+    if [[ -n "$progress" ]]; then
+        options="${options}p"
+    fi
 
     if [[ -n "$background" ]]; then
         cat << EOF
@@ -298,7 +339,6 @@ exit 1
     recovery and then reboot.
 
 EOF
-
         if [[ -n "$send_email" ]]; then
             cat << EOF
 An email with the log file will be sent to 'root' when the script finishes.
@@ -307,21 +347,13 @@ EOF
         fi
         echo "Log file is $log"
         echo ""
-        if [[ -z "$send_email" ]]; then
-            nohup "$0" -s "$special" "$log" 1>>$log 2>&1 &
-        else
-            nohup "$0"    "$special" "$log" 1>>$log 2>&1 &
-        fi
+        nohup "$0" "-$options" "$special" "$log" 1>>$log 2>&1 &
     else
         echo ""
         echo "Log file is $log"
         echo ""
-        if [[ -z "$send_email" ]]; then
-            options=-fs
-        else
-            options=-f
-        fi
-        "$0" "$options" "$special" "$log" 2>&1 |tee "$log"
+        options="${options}F"
+        "$0" "-$options" "$special" "$log" 2>&1 |tee "$log"
     fi
     exit
 fi
@@ -333,48 +365,60 @@ else
 fi
 date="$(date)"
 echo "Started at $date"
-echo ""
 
-if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
- echo "Can't proceed, '/usr2' is not mounted"
- exit 1
-fi
+if [[ -n "$initialize" ]]; then
 
-device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
-type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
+    if [ -z "`cat /proc/mounts | cut -d ' ' -f2 | grep /usr2`" ]; then
+     echo ""
+     echo "Can't proceed, '/usr2' is not mounted"
+     exit 1
+    fi
 
-if [[ -z "$background" ]]; then
-    cat << EOF
-    IMPORTANT: If you are logged out automatically, the refresh FAILED.  You
-               were probably on '/usr2' before you promoted to 'root'.  Try
-               again, but 'cd /tmp' before promoting to 'root'.
+    device=$(grep " /usr2 " /proc/mounts | cut -d' ' -f1)
+    type=$(grep " /usr2 " /proc/mounts | cut -d' ' -f3)
+
+    if [[ -z "$background" ]]; then
+        cat << EOF
+
+        IMPORTANT: If you are logged out automatically, the refresh FAILED.  You
+                   were probably on '/usr2' before you promoted to 'root'.  Try
+                   again, but 'cd /tmp' before promoting to 'root'.
 
 EOF
+    fi
+
+    fuser -k -M -m /usr2 || :
+    sleep 1
+
+    if [[ -n "$background" ]]; then
+        echo ""
+    fi
+    echo "Starting critical phase. Executing \"umount /usr2\" ..."
+    echo ""
+    umount /usr2
+    UUID=$(tune2fs -l $device | grep UUID | grep -o '[^ ]*$')
+    echo "Executing \"mke2fs -F -t $type -U $UUID $device\""
+    echo ""
+    mke2fs -F -t $type -U $UUID $device
+    mount /usr2
+    echo "... completed \"mount /usr2\".  The critical phase has finished."
+    if [[ -z "$background" ]]; then
+        echo "" >/dev/tty
+    fi
 fi
 
-fuser -k -M -m /usr2 || :
-sleep 1
-
-echo "Starting critical phase. Executing \"umount /usr2\" ..."
-echo ""
-umount /usr2
-UUID=$(tune2fs -l $device | grep UUID | grep -o '[^ ]*$')
-echo "Executing \"mke2fs -F -t $type -U $UUID $device\""
-echo ""
-mke2fs -F -t $type -U $UUID $device
-mount /usr2
-echo "... completed \"mount /usr2\".  The critical phase is finished."
-echo ""
-
 if [[ -z "$background" ]]; then
+    if [[ -z "$initialize" ]]; then
+        echo "" >/dev/tty
+    fi
     if [[ -n "$pv" ]]; then
         cat >/dev/tty << EOF
-    You may see two login messages from your Operational system.  If you are
-    prompted for the 'root' or other password on that system (twice), you
-    should provide it.  Then you will see a progress bar during the transfer.
+    You may see a login message from your Operational system.  If you are
+    prompted for the 'root' or other password on that system, you should
+    provide it.  Then a progress report will be displayed.
 EOF
     else
-       cat >/dev/tty << EOF
+        cat >/dev/tty << EOF
     You may see a login message from your Operational system  If you are
     prompted for the 'root' or other password on that system, you should
     provide it.  Then there will be a long pause without any output unless
@@ -387,9 +431,9 @@ EOF
     'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
     SCRIPT IS RUNNING' section of the '-h' help output for more details.
 
-    When the transfer finishes, a summary of the transfer will be printed and
-    you will see a line that starts: 'Done. ...', and get a prompt. Please
-    follow the directions on the 'Done. ...' line.
+    When the transfer finishes, the elapsed time of the transfer will be
+    printed and you will see a line that starts: 'Done. ...', and get a prompt.
+    Please follow the directions on the 'Done. ...' line.
 
 EOF
     if [[ -n "$send_email" ]]; then
@@ -400,29 +444,27 @@ EOF
     fi
 fi
 
-cat << EOF
-    If there are errors, please report them at
-    https://github.com/nvi-inc/fsl10/issues.
-
-EOF
-
 remote_user=root
-remote_command='cd /usr2; tar --one-file-system -cf - .'
+remote_dir=/usr2/
 
 # Use your Operational system name in place of 'operational' in the next line
 remote_node=operational
 
 # Uncomment the next two lines for CIS hardened systems
 #remote_user=spare
-#remote_command='sudo send_usr2'
+#remote_dir=/
 
-if [[ -n "$pv" && -z "$background" ]]; then
-    size="$(ssh $remote_user@$remote_node df|grep /usr2|tr -s ' '|cut -d ' ' -f 3)"k
-else
-    size=
+rsync_options=-aH
+if [[ -n "$ignore" ]]; then
+    rsync_options="${rsync_options}I"
 fi
 
-time ssh "$remote_user@$remote_node" "$remote_command" | safe_pv | (cd /usr2; tar xpf - --totals)
+if [[ -z "$background" ]]; then
+    rsync_options="${rsync_options}v"
+    time rsync "$rsync_options" --delete "$remote_user@$remote_node:$remote_dir" /usr2 | safe_pv >/dev/null
+else
+    time rsync "$rsync_options" --delete --stats --human-readable "$remote_user@$remote_node:$remote_dir" /usr2
+fi
 
 cat << EOF
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -341,7 +341,7 @@ EOF
         echo "Log file is $log"
         echo ""
         options="${options}F"
-        "$0" "-$options" "$special" "$log" 2>&1 |tee "$log"
+        stdbuf -o0 "$0" "-$options" "$special" "$log" 2>&1 |stdbuf -o0 tee "$log"
     fi
     exit
 fi

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -98,8 +98,12 @@ It is possible to use the operational system during the refresh if necessary,
 but this should be avoided if possible and activity on the '/usr2' partition
 should be as limited as possible.  You should not expect any changes on the
 operational system '/usr2' that occur after the refresh starts to be propagated
-to the spare system.  There may be some warnings that files cannot be found on
-the operational system if they are deleted before they are transferred.
+to the spare system.  If any files are deleted before they can be transferred,
+there will be a warning 'file has vanished: "..."', where '...' is the file
+name for each such file, and there will be a summary warning that starts with
+'rsync warning: some files vanished before they could be transferred', but
+without additional warnings or errors, the transfer should otherwise be
+successful.
 
 USING THE INITIALIZATION OPTION
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -70,8 +70,7 @@ the systems are quiescent.
 MODES
 
 The script has two modes, background, which is the default, and foreground
-using the '-f' option.  For background refreshes, the overall 'rsync' transfer
-statistics and overall time required are listed in the log file.
+using the '-f' option.
 
 For background refreshes, verify that it has finished, either from the log file
 or an email, before performing the finishing-up steps: checking that 'mdstat'
@@ -79,12 +78,13 @@ does not show an active recovery and then rebooting.  Those finishing-up steps
 are also needed for foreground mode, but it should be apparent from the screen
 output when the refresh has finished.
 
-For foreground refreshes, a progress report of the number of files transferred,
-elapsed time, and the rate of files be transferred is displayed if the 'pv'
-package is installed.  The number of files and the rate may appear to pause
-when very larges files are being transferred.  There is no ETA or percentage
-completion available.  The overall transfer statistics are not shown, but the
-overall time is still shown.
+For background refreshes, the overall 'rsync' transfer statistics and final
+overall time required are listed in the log file.
+
+For foreground refreshes, a progress meter will be displayed on the terminal.
+The two leftmost fields are the cumulative bytes transfers and the overall
+completion percentage.  The overall 'rsync' transfer statistics are not listed,
+but the final overall time is still listed.
 
 USING THE SYSTEMS WHILE THE SCRIPT IS RUNNING
 
@@ -170,20 +170,6 @@ obstacles to logging into the 'root' account remotely, with or without using
 'ssh' keys.  See the comments in the script for more information.
 
 EOF
-}
-
-# Check if pv (Pipe Viewer) is installed.
-# Used for progress bar
-if command -v pv &> /dev/null; then
-    pv=$(which pv)
-else
-    pv=
-fi
-
-safe_pv() {
-    if [[ -n "$pv" ]]; then
-        "$pv" -Wlbrt 2>/dev/tty
-    fi
 }
 
 short_me="$(basename $0)"
@@ -462,8 +448,7 @@ if [[ -n "$ignore" ]]; then
 fi
 
 if [[ -z "$background" ]]; then
-    rsync_options="${rsync_options}v"
-    time rsync "$rsync_options" --delete "$remote_user@$remote_node:$remote_dir" /usr2 | safe_pv >/dev/null
+    time rsync "$rsync_options" --delete --no-i-r --info=progress2 "$remote_user@$remote_node:$remote_dir" /usr2 >/dev/tty
 else
     time rsync "$rsync_options" --delete --stats --human-readable "$remote_user@$remote_node:$remote_dir" /usr2
 fi

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -127,8 +127,8 @@ script being aborted while using the '-I' option.
 CRITICAL PHASE
 
 In many cases, if the script is unexpectedly aborted when using the '-I'
-option, if it is possible to recover simply by rerunning the script.  An
-important exception this is if the abort occurs in the 'critical phase'.
+option, it is possible to recover simply by rerunning the script.  An important
+exception to this is if the abort occurs in the 'critical phase'.
 
 The critical phase of operation occurs between the printing of
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -89,17 +89,17 @@ but the final overall time is still listed.
 
 USING THE SYSTEMS WHILE THE SCRIPT IS RUNNING
 
-It is best to NOT login to an account on the spare system with a home directory
+It is best to NOT login to an account on the Spare system with a home directory
 on the '/usr2' partition (logging in as 'root' on a text console is okay) or
 otherwise access that partition during the refresh.  Accounts with home
-directories on the spare system '/usr2' partition may not be fully configured
+directories on the Spare system '/usr2' partition may not be fully configured
 until after the refresh completes.
 
-It is possible to use the operational system during the refresh if necessary,
+It is possible to use the Operational system during the refresh if necessary,
 but this should be avoided if possible and activity on the '/usr2' partition
 should be as limited as possible.  You should not expect any changes on the
-operational system '/usr2' that occur after the refresh starts to be propagated
-to the spare system.  If any files are deleted before they can be transferred,
+Operational system '/usr2' that occur after the refresh starts to be propagated
+to the Spare system.  If any files are deleted before they can be transferred,
 there will be a warning 'file has vanished: "..."' for each such file, where
 '...' is the file name, and there will be a summary warning that starts with
 'rsync warning: some files vanished before they could be transferred', but
@@ -110,7 +110,7 @@ USING THE INITIALIZATION OPTION
 
 When using the '-I' option, it is recommended that you login on a text console
 as 'root'.  Alternatively, you could login as a non-'root' user either on a
-console or by 'ssh' from another system (preferably not the operational
+console or by 'ssh' from another system (preferably not the Operational
 system).  For either approach as a non-'root' user, you must make sure your
 working directory is not on '/usr2', for example by using 'cd /tmp', before
 running the script.  It is best to get off '/usr2' before promoting to 'root'.
@@ -302,7 +302,7 @@ exit 1
     Going to background, you should log out now or you may be logged out
     automatically.
 
-    It is best to NOT login into either the spare or operational system while
+    It is best to NOT login to either the Spare or Operational system while
     'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
     SCRIPT IS RUNNING' section of the '-h' help output for more details.
 
@@ -384,7 +384,7 @@ if [[ -z "$background" ]]; then
     prompted for the 'root' or other password on that system, you should
     provide it.  Then progress information from 'rsync' will be displayed.
 
-    It is best to NOT login into either the spare or operational system while
+    It is best to NOT login to either the Spare or Operational system while
     'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
     SCRIPT IS RUNNING' section of the '-h' help output for more details.
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -43,7 +43,7 @@ OPTIONS
  -Y       Yes: proceed without prompting for confirmation
 
 The '-i' option should only be rarely needed.  It is recommended to NOT use
-uppercase options except in special circumstances.
+the uppercase options except in special circumstances.
 
 DESCRIPTION
 
@@ -71,12 +71,12 @@ MODES
 
 The script has two modes, background, which is the default, and foreground
 using the '-f' option.  For background refreshes, the overall 'rsync' transfer
-statistics and overall time required  are included in the log file.
+statistics and overall time required are listed in the log file.
 
 For background refreshes, verify that it has finished, either from the log file
-or an email, before performing the finishing up steps: checking that 'mdstat'
-does not show an active recovery and then rebooting.  Those finishing up steps
-are also need for foreground mode, but it should be apparent from the screen
+or an email, before performing the finishing-up steps: checking that 'mdstat'
+does not show an active recovery and then rebooting.  Those finishing-up steps
+are also needed for foreground mode, but it should be apparent from the screen
 output when the refresh has finished.
 
 For foreground refreshes, a progress report of the number of files transferred,
@@ -140,9 +140,9 @@ and
 
 If the script is interrupted or otherwise fails between these commands, it will
 usually be necessary to take corrective action.  This normally consists of
-re-executing (using copy-and-paste) the contents (everything from between the
+re-executing (using copy-and-paste) the command (everything from between the
 double quotes, typically a long string that will probably overwrap your
-terminal width) of the output line
+terminal width) shown in the output line
 
     Executing "mke2fs -F -t ..."
 
@@ -178,7 +178,7 @@ fi
 
 safe_pv() {
     if [[ -n "$pv" ]]; then
-        $pv -Wlbrt 2>/dev/tty
+        "$pv" -Wlbrt 2>/dev/tty
     fi
 }
 
@@ -320,9 +320,6 @@ exit 1
     fi
     if [[ -n "$initialize" ]]; then
         options="${options}I"
-    fi
-    if [[ -n "$progress" ]]; then
-        options="${options}p"
     fi
 
     if [[ -n "$background" ]]; then

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -64,7 +64,7 @@ If the script is aborted while it is running, it is usually possible to recover
 by simply rerunning it.  An important exception to this when using the '-I'
 option is described, with recovery steps, in the CRITICAL PHASE section below.
 
-The script may take up to three times longer to complete if both the
+The script may take about three times longer to complete if both the
 Operational and Spare systems are refreshing their secondary disks than when
 the systems are quiescent.
 
@@ -306,7 +306,7 @@ exit 1
     'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE
     SCRIPT IS RUNNING' section of the '-h' help output for more details.
 
-    After the refresh has finished wait, until 'mdstat' does not show an active
+    After the refresh has finished, wait until 'mdstat' does not show an active
     recovery and then reboot.
 
 EOF
@@ -323,8 +323,7 @@ EOF
         echo ""
         echo "Log file is $log"
         echo ""
-        options="${options}F"
-        "$0" "-$options" "$special" "$log" 2>&1 | tee "$log"
+        "$0" "-${options}F" "$special" "$log" 2>&1 | tee "$log"
     fi
     exit
 fi
@@ -379,23 +378,11 @@ if [[ -z "$background" ]]; then
 # keep foreground messages in order, this delay may not always be long enough
     sleep 0.1
 
-    if [[ -n "$pv" ]]; then
-        cat >/dev/tty << EOF
+    cat >/dev/tty << EOF
 
     You may see a login message from your Operational system.  If you are
     prompted for the 'root' or other password on that system, you should
-    provide it.  Then a progress report will be displayed.
-EOF
-    else
-        cat >/dev/tty << EOF
-
-    You may see a login message from your Operational system  If you are
-    prompted for the 'root' or other password on that system, you should
-    provide it.  Then there will be a long pause without any output unless
-    there are errors.
-EOF
-    fi
-    cat >/dev/tty << EOF
+    provide it.  Then progress information from 'rsync' will be displayed.
 
     It is best to NOT login into either the spare or operational system while
     'refresh_spare_usr2' is running, but see the 'USING THE SYSTEMS WHILE THE

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -30,7 +30,7 @@ have both Operational and Spare systems.  Rebooting afterwards is recommended.
 IMPORTANT: This script will overwrite everything on the '/usr2' partition of
            the system it is run on.  Use it only on the Spare system.
 
-Usage: $0 [options]
+Usage: $short_me [options]
 
 OPTIONS
 
@@ -182,6 +182,7 @@ safe_pv() {
     fi
 }
 
+short_me="$(basename $0)"
 background=1
 proceed=
 send_email=1
@@ -211,11 +212,11 @@ while getopts FhiINsY opt; do
             proceed=1
             ;;
         *)
-            echo "Use '$0 -h' for help" >&2
+            echo "Use '$short_me -h' for help" >&2
             exit 1
             ;;
         :)
-            echo "Use '$0 -h' for help" >&2
+            echo "Use '$short_me -h' for help" >&2
             exit 1
           ;;
     esac
@@ -360,8 +361,8 @@ if [[ -z "$background" ]]; then
 else
     echo "Refreshing Spare system disk '/usr2' partition in background ..."
 fi
-date="$(date)"
-echo "Started at $date"
+echo "Started at $(date)"
+echo "[$short_me version 3.0]"
 
 if [[ -n "$initialize" ]]; then
 

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -101,7 +101,7 @@ should be as limited as possible.  You should not expect any changes on the
 operational system '/usr2' that occur after the refresh starts to be propagated
 to the spare system.  If any files are deleted before they can be transferred,
 there will be a warning 'file has vanished: "..."' for each such file, where
-'...' is file name, and there will be a summary warning that starts with
+'...' is the file name, and there will be a summary warning that starts with
 'rsync warning: some files vanished before they could be transferred', but
 without additional warnings or errors, the transfer should otherwise be
 successful.
@@ -143,7 +143,7 @@ and
 
     ... completed "mount /usr2". The critical phase has finished.
 
-If t$e script is interrupted or otherwise fails between these outputs, it will
+If the script is interrupted or otherwise fails between these outputs, it will
 usually be necessary to take corrective action.  This normally consists of
 re-executing (using copy-and-paste) the command (everything from between the
 double quotes, typically a long string that will probably overwrap your

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -24,8 +24,9 @@ set -e
 usage() {
     cat << EOF
 
-This script refreshes the contents of the Spare system '/usr2' partition if you
-have both Operational and Spare systems.  Rebooting afterwards is recommended.
+This script refreshes the contents of the Spare system disk '/usr2' partition
+if you have both Operational and Spare systems.  Rebooting afterwards is
+recommended.
 
 IMPORTANT: This script will overwrite everything on the '/usr2' partition of
            the system it is run on.  Use it only on the Spare system.
@@ -82,7 +83,7 @@ For background refreshes, the overall 'rsync' transfer statistics and final
 overall time required are listed in the log file.
 
 For foreground refreshes, a progress meter will be displayed on the terminal.
-The two leftmost fields are the cumulative bytes transfers and the overall
+The two leftmost fields are the cumulative bytes transferred and the overall
 completion percentage.  The overall 'rsync' transfer statistics are not listed,
 but the final overall time is still listed.
 
@@ -99,8 +100,8 @@ but this should be avoided if possible and activity on the '/usr2' partition
 should be as limited as possible.  You should not expect any changes on the
 operational system '/usr2' that occur after the refresh starts to be propagated
 to the spare system.  If any files are deleted before they can be transferred,
-there will be a warning 'file has vanished: "..."', where '...' is the file
-name for each such file, and there will be a summary warning that starts with
+there will be a warning 'file has vanished: "..."' for each such file, where
+'...' is file name, and there will be a summary warning that starts with
 'rsync warning: some files vanished before they could be transferred', but
 without additional warnings or errors, the transfer should otherwise be
 successful.
@@ -142,7 +143,7 @@ and
 
     ... completed "mount /usr2". The critical phase has finished.
 
-If the script is interrupted or otherwise fails between these commands, it will
+If t$e script is interrupted or otherwise fails between these outputs, it will
 usually be necessary to take corrective action.  This normally consists of
 re-executing (using copy-and-paste) the command (everything from between the
 double quotes, typically a long string that will probably overwrap your
@@ -159,15 +160,8 @@ again.
 
 INSTALLATION
 
-This script must be customized before it is used.  Directions for that are
-embedded in the script.
-
-It may not be possible to setup the script to login into the Operational system
-with 'ssh' keys.  If not, it may still be possible to connect with a password;
-in which case, the script will only work if used with '-f', foreground mode.
-Using the CIS hardening approach may be a usable alternative if there are
-obstacles to logging into the 'root' account remotely, with or without using
-'ssh' keys.  See the comments in the script for more information.
+This script must be customized before it is used.  The installation
+instructions are included in comments in the script.
 
 EOF
 }
@@ -266,33 +260,22 @@ exit 1
 #
 # To customize this script (as 'root') on the Spare system:
 #   1. MAKE ABSOLUTELY SURE YOU ARE WORKING ON THE SPARE SYSTEM.
-#   2. Execute the commands:
-#        cd /usr/local/sbin
-#        cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
-#        chown root.root refresh_spare_usr2
-#        chmod a+r,u+wx,go-wx refresh_spare_usr2
-#   3. Edit '/usr/local/sbin/refresh_spare_usr2':
+#   2. Edit '/usr/local/sbin/refresh_spare_usr2':
 #        A. Comment out the two commands above (add leading '#'s).
 #        B  Change the 'operational' in the 'remote_node=operational' line
 #           below to the alias (preferred), FQDN, or IP address of your
-#           Operational system  (There are additional instructions a little
-#           after that line for more customizations for CIS hardened systems.)
-#        C. Save the result.
-#   4. The 'ssh' keys for 'root' on the Spare system should be copied to the
-#      target account on the Operational system.  That system should also be
-#      set to allow 'ssh' connections to that account from the Spare system.
-#      If these two things cannot be done, the target account must allow
-#      password login; in which case, only '-f', foreground mode, will be
-#      usable.  The CIS hardening approach may be a useful alternative if there
-#      are problems with using 'ssh' keys to log into the 'root' account.  For
-#      more information, see the 'Installing refresh_spare_usr2 with CIS
-#      hardening' subsection of the 'CIS Hardending for FSL10 document'.  You
-#      may find the description of how to modify that approach to use the
-#      'root' account in the 'refresh_spare_usr2' subsection of the 'RAID Notes
-#      for FSL10' useful.
-#   5. Test it the first time just after the Spare system's disk has been
+#           Operational system.
+#        C. For CIS hardened systems only: uncomment the line (remove the
+#           leading '#') '#remote_user=spare'.
+#        D. Save the result.
+#   3. Follow the other directions in the 'Installing refresh_spare_usr2'
+#      subsection of the 'RAID Notes for FSL10' document.
+#      The CIS hardening approach may be a useful alternative, or necessary if
+#      you have a CIS hardened system.  For more information, see the
+#      'Installing refresh_spare_usr2 with CIS hardening' subsection of the
+#      'CIS Hardening for FSL10' document.
+#   4. Test it the first time just after the Spare system's disk has been
 #      rotated.
-#
 
 # setup for log file
     dir=/root/refresh_spare_usr2_logs
@@ -433,14 +416,12 @@ EOF
 fi
 
 remote_user=root
-remote_dir=/usr2/
 
 # Use your Operational system name in place of 'operational' in the next line
 remote_node=operational
 
-# Uncomment the next two lines for CIS hardened systems
+# Uncomment the next line for CIS hardened systems
 #remote_user=spare
-#remote_dir=/
 
 rsync_options=-aH
 if [[ -n "$ignore" ]]; then
@@ -448,9 +429,9 @@ if [[ -n "$ignore" ]]; then
 fi
 
 if [[ -z "$background" ]]; then
-    time rsync "$rsync_options" --delete --no-i-r --info=progress2 "$remote_user@$remote_node:$remote_dir" /usr2 >/dev/tty
+    time rsync "$rsync_options" --delete --no-i-r --info=progress2 "$remote_user@$remote_node:/" /usr2 >/dev/tty
 else
-    time rsync "$rsync_options" --delete --stats --human-readable "$remote_user@$remote_node:$remote_dir" /usr2
+    time rsync "$rsync_options" --delete --stats --human-readable "$remote_user@$remote_node:/" /usr2
 fi
 
 cat << EOF

--- a/RAID/refresh_spare_usr2
+++ b/RAID/refresh_spare_usr2
@@ -324,7 +324,7 @@ EOF
         echo "Log file is $log"
         echo ""
         options="${options}F"
-        stdbuf -o0 "$0" "-$options" "$special" "$log" 2>&1 |stdbuf -o0 tee "$log"
+        "$0" "-$options" "$special" "$log" 2>&1 | tee "$log"
     fi
     exit
 fi
@@ -335,7 +335,7 @@ else
     echo "Refreshing Spare system disk '/usr2' partition in background ..."
 fi
 echo "Started at $(date)"
-echo "[$short_me version 3.0]"
+echo "[$short_me 3.0]"
 
 if [[ -n "$initialize" ]]; then
 
@@ -373,23 +373,22 @@ EOF
     mke2fs -F -t $type -U $UUID $device
     mount /usr2
     echo "... completed \"mount /usr2\".  The critical phase has finished."
-    if [[ -z "$background" ]]; then
-        echo "" >/dev/tty
-    fi
 fi
 
 if [[ -z "$background" ]]; then
-    if [[ -z "$initialize" ]]; then
-        echo "" >/dev/tty
-    fi
+# keep foreground messages in order, this delay may not always be long enough
+    sleep 0.1
+
     if [[ -n "$pv" ]]; then
         cat >/dev/tty << EOF
+
     You may see a login message from your Operational system.  If you are
     prompted for the 'root' or other password on that system, you should
     provide it.  Then a progress report will be displayed.
 EOF
     else
         cat >/dev/tty << EOF
+
     You may see a login message from your Operational system  If you are
     prompted for the 'root' or other password on that system, you should
     provide it.  Then there will be a long pause without any output unless

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.4.3 - September 2021
+Version 1.5.0 - September 2021
 
 :experimental:
 :toc:

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.5.0 - September 2021
+Version 1.5.0 - October 2021
 
 :experimental:
 :toc:

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.4.1 - September 2021
+Version 1.4.2 - September 2021
 
 :experimental:
 :toc:
@@ -721,7 +721,7 @@ to confirm connecting. Finally, logout of the `spare` account on
 
 NOTE: This subsection follows the FS manual font conventions.
 
-IMPORTANT: Please read the
+TIP: Read the
 <<raid.adoc#_refresh_spare_usr2,refresh_spare_usr2>> section of the
 <<raid.adoc#,RAID Notes for FSL10>> document for important information
 on the __refresh_spare_usr2__ script.
@@ -731,24 +731,6 @@ _refresh_spare_usr2_ script with CIS hardening. All steps must be
 executed as _root_.
 
 . On the _operational_ system:
-
-.. Install the _rrsync_ script:
-
-+
-
-....
-gunzip -c /usr/share/doc/rsync/scripts/rrsync.gz >/usr/local/bin/rrsync
-ln -s /usr/local/bin/rrsync /usr/bin/rrsync
-chmod u+x,go-x /usr/local/bin/rrsync
-....
-
-.. Use _visudo_ to add:
-
-+
-
-....
-spare          ALL=(ALL) NOPASSWD:SETENV: /usr/bin/rrsync
-....
 
 .. Create _spare_ account:
 
@@ -764,7 +746,8 @@ keep the values in sync for users on both systems. In other words, it
 is not necessary to worry about jumping over a low value on the
 _spare_ system when values are assigned sequentially, as is the
 default. If you think you might have more than 1000 users or groups,
-you might want to increase the values for the _spare_ account.
+you might want to increase the values for the _spare_ account and
+group.
 
 +
 
@@ -777,29 +760,55 @@ adduser spare --uid 2000 --gid 2000
 
 . On the _spare_ system:
 
-.. Customize _refresh_spare_usr2_
+.. Install _refresh_spare_usr2_:
 
+  cd /usr/local/sbin
+  cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
+  chown root.root refresh_spare_usr2
+  chmod a+r,u+wx,go-wx refresh_spare_usr2
+
+.. Customize _refresh_spare_usr2_, following the directions in the
+comments in the script:
+
+... Comment-out the lines (add leading ``#``s):
 
 +
 
-The un-customized script is provided in
-_/root/fsl10/RAID/refresh_spare_usr2_. Follow the directions in the
-comments, being sure to _uncomment_ the two lines for CIS hardened
-systems. Their commented out form is:
+....
+echo "This script must be customized before use.  See script for details."
+exit 1
+....
+
+... Change the `operational` in the line:
+
++
+
+....
+remote_node=operational
+....
+
++
+
+to the alias (preferred), FQDN, or IP address of your _operational_
+system.
+
+... Uncomment the line for CIS hardened systems. The commented out
+form is:
+
++
 
 +
 
 ....
 #remote_user=spare
-#remote_dir=/
 ....
 
-.. Create and copy a key for _root_
+.. Create and copy a key for _root_:
 
 +
 
-If _root_ already has a key, you only need the second command below to
-copy it to the _spare_ account:
+NOTE: If _root_ already has a key, you only need the second command
+below to copy it to the _spare_ account:
 
 +
 
@@ -818,11 +827,11 @@ ssh-copy-id spare@_operational_
 where `_operational_` is the alias, name, or IP of your _operational_
 system.
 
-.. Enable _sudo_ to run the script
+.. Enable _sudo_ to run the script:
 
 +
 
-Use _visudo_ to add
+Use _visudo_ to add:
 
 +
 
@@ -834,10 +843,21 @@ Use _visudo_ to add
 
 +
 
-NOTE: It could be limited to a specific user (but not _oper_ or
-_prog_) by replacing `%operators` with the user account name.
+NOTE: It could be setup for a specific user (but not _oper_ or _prog_
+in a CIS hardened system) by replacing `%operators` with the user
+account name.
 
 . On the _operational_ system:
+
+.. Install the _rrsync_ script:
+
++
+
+....
+gunzip -c /usr/share/doc/rsync/scripts/rrsync.gz >/usr/local/bin/rrsync
+ln -s /usr/local/bin/rrsync /usr/bin/rrsync
+chmod u+x,go-x /usr/local/bin/rrsync
+....
 
 .. Set the _spare_ account to only allow a _forced command_ with _ssh_
 by replacing the `ssh-rsa` at the start of the first (and only) line of
@@ -846,6 +866,14 @@ _~spare/.ssh/authorized_keys_ line with:
 +
 
 `command="sudo --preserve-env rrsync -ro /usr2" ssh-rsa`
+
+.. Use _visudo_ to add:
+
++
+
+....
+spare          ALL=(ALL) NOPASSWD:SETENV: /usr/bin/rrsync
+....
 
 .. Lock out spare account from normal login (but it must have a
 shell). This will disable password login, but not _ssh_ login with

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.4.2 - September 2021
+Version 1.4.3 - September 2021
 
 :experimental:
 :toc:
@@ -726,18 +726,28 @@ TIP: Read the
 <<raid.adoc#,RAID Notes for FSL10>> document for important information
 on the __refresh_spare_usr2__ script.
 
-This sub-section describes the steps needed to enable use of the
+This subsection describes the steps needed to enable use of the
 _refresh_spare_usr2_ script with CIS hardening. All steps must be
-executed as _root_.
+performed as _root_ on the specified system. You should read all of
+each step or sub-step before following it.
 
 . On the _operational_ system:
 
-.. Create _spare_ account:
+.. Create _spare_ account. Execute:
+
++
+
+----
+addgroup spare --gid 2000
+adduser spare --uid 2000 --gid 2000
+----
 
 +
 
 NOTE: The user's home directory is on _/home_ (by default), not
 _/usr2_.
+
++
 
 +
 
@@ -749,18 +759,9 @@ default. If you think you might have more than 1000 users or groups,
 you might want to increase the values for the _spare_ account and
 group.
 
-+
+. On the _spare_ system.
 
-----
-addgroup spare --gid 2000
-adduser spare --uid 2000 --gid 2000
-----
-
-+
-
-. On the _spare_ system:
-
-.. Install _refresh_spare_usr2_:
+.. Install _refresh_spare_usr2_. Execute:
 
   cd /usr/local/sbin
   cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
@@ -803,16 +804,7 @@ form is:
 #remote_user=spare
 ....
 
-.. Create and copy a key for _root_:
-
-+
-
-NOTE: If _root_ already has a key, you only need the second command
-below to copy it to the _spare_ account:
-
-+
-
-NOTE: It is recommended to not set a passphrase.
+.. Create and copy a key for _root_. Execute:
 
 +
 
@@ -827,11 +819,16 @@ ssh-copy-id spare@_operational_
 where `_operational_` is the alias, name, or IP of your _operational_
 system.
 
-.. Enable _sudo_ to run the script:
++
+
+NOTE: If _root_ already has a key, you only need the second command
+above to copy it to the _spare_ account:
 
 +
 
-Use _visudo_ to add:
+NOTE: It is recommended to not set a passphrase.
+
+.. Enable running the script with _sudo_. Use _visudo_ to add:
 
 +
 
@@ -849,7 +846,7 @@ account name.
 
 . On the _operational_ system:
 
-.. Install the _rrsync_ script:
+.. Install the _rrsync_ script. Execute:
 
 +
 
@@ -867,7 +864,7 @@ _~spare/.ssh/authorized_keys_ line with:
 
 `command="sudo --preserve-env rrsync -ro /usr2" ssh-rsa`
 
-.. Use _visudo_ to add:
+.. Enable _spare_ to run _rrsync_ with _sudo_. Use _visudo_ to add:
 
 +
 
@@ -877,7 +874,7 @@ spare          ALL=(ALL) NOPASSWD:SETENV: /usr/bin/rrsync
 
 .. Lock out spare account from normal login (but it must have a
 shell). This will disable password login, but not _ssh_ login with
-keys, for this user:
+keys, for this user. Execute:
 
 
 +
@@ -886,7 +883,8 @@ keys, for this user:
 usermod -L spare
 ----
 
-.. Disable password aging and inactivity time-out for this account:
+.. Disable password aging and inactivity time-out for this account,
+Execute:
 
 +
 

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -826,7 +826,7 @@ above to copy it to the _spare_ account:
 
 +
 
-NOTE: It is recommended to not set a passphrase.
+TIP: It is recommended to not set a passphrase.
 
 .. Enable running the script with _sudo_. Use _visudo_ to add:
 
@@ -864,7 +864,22 @@ _~spare/.ssh/authorized_keys_ line with:
 
 `command="sudo --preserve-env rrsync -ro /usr2" ssh-rsa`
 
-.. Enable _spare_ to run _rrsync_ with _sudo_. Use _visudo_ to add:
++
+
++
+
++
+
+TIP: If your _spare_ system is registered with DNS, you can provide
+some additional security by adding ``from="__node__" `` {nbsp}(note
+the trailing space) at the start of the line, where `__node__` is the
+FQDN or IP address of the _spare_ system.  It may be necessary to
+provide the FQDN, IP address, and/or alias of the _spare_ system in a
+comma separated list in place of  `__node__` to get reliable
+operation.
+
+.. Enable the _spare_ account to run _rrsync_ with _sudo_ without a
+password and passing environment variables. Use _visudo_ to add:
 
 +
 
@@ -872,9 +887,9 @@ _~spare/.ssh/authorized_keys_ line with:
 spare          ALL=(ALL) NOPASSWD:SETENV: /usr/bin/rrsync
 ....
 
-.. Lock out spare account from normal login (but it must have a
+.. Lock-out the _spare_ account from normal login (but it must have a
 shell). This will disable password login, but not _ssh_ login with
-keys, for this user. Execute:
+keys, for this account. Execute:
 
 
 +
@@ -883,8 +898,8 @@ keys, for this user. Execute:
 usermod -L spare
 ----
 
-.. Disable password aging and inactivity time-out for this account,
-Execute:
+.. Disable password aging and inactivity time-out for the _spare_
+account. Execute:
 
 +
 

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.4.0 - September 2021
+Version 1.4.1 - September 2021
 
 :experimental:
 :toc:
@@ -727,32 +727,28 @@ IMPORTANT: Please read the
 on the __refresh_spare_usr2__ script.
 
 This sub-section describes the steps needed to enable use of the
-_refresh_spare_usr2_ script with CIS hardening.
+_refresh_spare_usr2_ script with CIS hardening. All steps must be
+executed as _root_.
 
 . On the _operational_ system:
+
+.. Install the _rrsync_ script:
+
++
+
+....
+gunzip -c /usr/share/doc/rsync/scripts/rrsync.gz >/usr/local/bin/rrsync
+ln -s /usr/local/bin/rrsync /usr/bin/rrsync
+chmod u+x,go-x /usr/local/bin/rrsync
+....
 
 .. Use _visudo_ to add:
 
 +
 
 ....
-spare          ALL=(ALL) NOPASSWD: /usr/local/sbin/send_usr2
+spare          ALL=(ALL) NOPASSWD:SETENV: /usr/bin/rrsync
 ....
-
-.. Create file:
-
-+
-
-./usr/local/sbin/send_usr2
-[source,bash]
-----
-#!/bin/bash
-cd /usr2; tar --one-file-system -cf - .
-----
-
-+
-
-Permissions: `rwxr--r--`, ownership `root:root`.
 
 .. Create _spare_ account:
 
@@ -779,14 +775,14 @@ adduser spare --uid 2000 --gid 2000
 
 +
 
-. On the _spare_ system
+. On the _spare_ system:
 
 .. Customize _refresh_spare_usr2_
 
 
 +
 
-The uncustomized script is provided in
+The un-customized script is provided in
 _/root/fsl10/RAID/refresh_spare_usr2_. Follow the directions in the
 comments, being sure to _uncomment_ the two lines for CIS hardened
 systems. Their commented out form is:
@@ -795,7 +791,7 @@ systems. Their commented out form is:
 
 ....
 #remote_user=spare
-#remote_command='sudo send_usr2'
+#remote_dir=/
 ....
 
 .. Create and copy a key for _root_
@@ -838,10 +834,18 @@ Use _visudo_ to add
 
 +
 
-It could be limited to a specific user (but not _oper_ or _prog_)
-by replacing `%operators` with the user account name.
+NOTE: It could be limited to a specific user (but not _oper_ or
+_prog_) by replacing `%operators` with the user account name.
 
-. On the _operational_ system
+. On the _operational_ system:
+
+.. Set the _spare_ account to only allow a _forced command_ with _ssh_
+by replacing the `ssh-rsa` at the start of the first (and only) line of
+_~spare/.ssh/authorized_keys_ line with:
+
++
+
+`command="sudo --preserve-env rrsync -ro /usr2" ssh-rsa`
 
 .. Lock out spare account from normal login (but it must have a
 shell). This will disable password login, but not _ssh_ login with
@@ -863,104 +867,3 @@ usermod -L spare
 ----
 chage -I -1 -M 99999 spare
 ----
-
-== Using refresh_spare_usr2 with CIS hardening
-
-NOTE: This section follows the FS manual font conventions.
-
-. As part of a monthly backup, you would usually start a disk rotation
-on both the _operational_ and _spare_ systems first. Once both
-systems are recovering, you should log out of both systems.
-
-+
-
-IMPORTANT: Before proceeding, make sure that no one is logged into
-either system and that no processes are running on _/usr2_ on either
-system, particularly the FS.
-
-. Login to the _spare_ system with an AUID account on a local virtual
-console text terminal or from another system (not the _operational_
-system) using _ssh_.
-
-
-+
-
-IMPORTANT: If you logged in using _ssh_ do not open an _xterm_ to work
-in. Instead work in the window where you logged in.
-
-. Execute:
-+
-    cd /tmp
-    sudo refresh_spare_usr2
-+
-Answer the question `*y*` if it is safe to proceed.
-
-. Log out of the system, if you weren't logged out automatically.
-
-. Wait until the script has finished before resuming other activities
-on the systems.
-
-+
-
-CAUTION: Generally speaking, it is best to _not_ login to either the
-_spare_ or _operational_ system while the script is running, but see
-the <<note,NOTE>> below for more information.
-
-+
-
-An email will be sent to _root_ when the refresh finishes. If your
-email to _root_ is being forwarded to a mailbox off the system, you
-can use receipt of that message (and that it shows no errors) as the
-indication that it finished successfully.
-
-+
-
-If emails to _root_ are _not_ being forwarded off the system and you
-_can_ login as _root_ on a text console, you can check _root_'s email
-for the message.
-
-+
-
-Alternatively, you can use the time it took previous refreshes to
-finish to estimate how log this one may take. You can examine the logs
-(before starting the refresh) in _/root/refresh_spare_usr2_logs_ to
-see how long previous refreshes took. Typically a new refresh will
-take a little longer than the most recent previous refresh. You can
-check the log for the current refresh after at least that much time
-has elapsed to verify that it has finished.
-
-+
-
-[[note]]
-[NOTE]
-====
-
-Do not login to an account on the _spare_ system with a home directory
-on the _/usr2_ partition (logging in as _root_ on a text console is
-okay) or otherwise access that partition during the refresh.
-
-It is possible to use the _operational_ system during the refresh if
-necessary, but this should be avoided if possible and activity on the
-_/usr2_ partition should be as limited as possible.  You should not
-expect any changes on the _operational_ system _/usr2_ that occur
-after the refresh starts to be propagated to the _spare_ system.  If
-any files on the _operational_ system _/usr2_ are deleted from it
-before they could be copied, there may be error messages like:
-
-[subs="+quotes"]
-....
-tar: _file_: Cannot stat: No such file or directory
-....
-
-for those ``_file_``s and a final summary error message:
-
-  tar: Exiting with failure status due to previous errors
-
-but without other errors the refresh should still generally succeed.
-
-====
-
-. If it finished with no problems, you can reboot as soon as is
-convenient. You may reboot even if the RAID is recovering, but you can
-wait until the recovery is complete. The only requirement is to reboot
-before the FS is run again on the _spare_ system.

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.5.0 - September 2021
+Version 1.5.0 - October 2021
 
 :sectnums:
 :experimental:

--- a/installation.adoc
+++ b/installation.adoc
@@ -20,7 +20,7 @@
 
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.4.0 - September 2021
+Version 1.5.0 - September 2021
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.1 - September 2021
+Version 1.4.2 - September 2021
 
 :sectnums:
 :experimental:
@@ -757,7 +757,7 @@ as _root_.
 An alternative is to login as a non-_root_ user either on a text
 console or by _ssh_ from another system (not the _operational_
 system). In this case, you should promote to _root_ using _su_ or run
-the script with _sudo_.
+the script with _sudo_ (or _root_account_ for CIS hardened systems).
 
 
 . Execute:
@@ -770,10 +770,10 @@ Answer the question `*y*` if it is safe to proceed.
 
 +
 
-. Log out of the system, if you weren't logged out automatically.
+. Log out of the system.
 
-. Wait until the script has finished before resuming other activities
-on the systems.
+. Wait until the script has finished before logging in again and
+resuming other activities on the systems.
 
 +
 
@@ -783,14 +783,14 @@ on the systems.
 Generally speaking, it is best to _not_ login to either the _spare_ or
 _operational_ system while the script is running.
 
-If logging in on the _spare_ commuter, it is best to _not_ login to an
+If you do login to the _spare_ commuter, it is best to _not_ use an
 account with a home directory on the _/usr2_ partition (logging in as
 _root_ on a text console is okay) or otherwise access that partition
-during the refresh.  Accounts with home directories on the spare
-system _/usr2_ partition may not be fully configured until after the
-refresh completes. As a result, some accounts that you are use to
-logging into  with _ssh_ keys may require a password until the keys
-are transferred.
+while the script is running. Accounts with home directories on the
+spare system _/usr2_ partition may not be fully configured until after
+the refresh completes. As a result, some accounts that you are use to
+logging into with _ssh_ keys may require a password until the keys are
+transferred.
 
 It is possible to use the operational system during the refresh if
 necessary, but this should be avoided if possible and activity on the

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.5 - September 2021
+Version 1.4.7 - September 2021
 
 :sectnums:
 :experimental:
@@ -662,9 +662,9 @@ systems. Once the RAIDs on both systems are _recovering_ you can
 log-out of both systems and then login into the _spare_ system again
 to start _refresh_spare_usr2_.
 
-The recovery of the RAIDs will increase the amount of time that the
-_refresh_spare_usr2_ takes to complete. It has been observed in some
-cases to approximately double the time required.
+While a _refresh_spare_usr2_  with two nearly synchronized _/usr2_
+partitions is fairly fast, the recovery of the RAIDs may increase the
+amount of time required by about a factor of three.
 
 Once _refresh_spare_usr2_ completes, it is safe to reboot, even if a
 recovery is still ongoing. The only requirement is to reboot the

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.0 - September 2021
+Version 1.4.1 - September 2021
 
 :sectnums:
 :experimental:
@@ -651,34 +651,10 @@ instructions for its installation are included in the script. The
 script will give a warning about its use and prompt for permission to
 proceed when it it is run.
 
+A full description of the features of the script are available from
+the `*refresh_spare_usr2{nbsp}-h*` output.
+
 IMPORTANT: It should be installed on the _spare_ system _only_.
-
-WARNING: When this script is run, neither system should have anyone
-logged in with a home directory on _/usr2_ nor should there be any
-activity occurring that will affect _/usr2_.
-
-WARNING: For this script to work usefully, the _operational_ and
-_spare_ systems should have the same set-up including particularly the
-same user accounts with same UIDs and GIDs in parallel for all
-accounts, particularly for those that have home directories on
-_/usr2_, as well as other OS set-up information the FS may depend ons
-such as _/etc/hosts_ and _/etc/ntp.conf_.
-
-IMPORTANT: It is recommended that the script be used (including for
-initial testing) immediately after a disk rotation to provide the
-ample opportunities for recovery if there is a problem. In particular,
-for initial testing the procedure in the <<Recoverable testing>>
-section above should be used.
-
-TIP: If the script is accidentally terminated with a kbd:[Ctrl+C] (in
-foreground) or otherwise aborted, it is usually possible to recover by
-rerunning the script. A significant exception is if the abort occurs
-during the _mke2fs_ command. For this reason, the script prints that
-command to the log (and the terminal, when run in foreground) to allow
-the user to copy-and-paste the command to re-execute it, in case that
-is ever needed. Steps for recovery from an abort, which are fairly
-easy, are discussed in the `CRITICAL PHASE` section of the
-`*refresh_spare_usr2{nbsp}-h*` output.
 
 [TIP]
 ====
@@ -701,6 +677,66 @@ shelf disk a deeper back-up than the _spare_ system RAID disks.
 
 ====
 
+==== Installing refresh_spare_usr2
+
+Instructions for customizing _refresh_spare_usr2_ for your system are included
+in comments in the script.  If it has not been customized yet, it will print
+a message indicating that this is needed and exit.
+
+WARNING: For this script to work most usefully, the _operational_ and
+_spare_ systems should have the same set-up including particularly the
+same user accounts with same UIDs and GIDs in parallel for all
+accounts, particularly for those that have home directories on
+_/usr2_, as well as other OS set-up information the FS may depend on
+such as _/etc/hosts_ and _/etc/ntp.conf_.
+
+[TIP]
+====
+
+If you are unable to use login to the _operational_ system with _ssh_
+keys from the _spare_ system, you may be able to use the approach
+given in the
+<<cis-setup.adoc#_installing_refresh_spare_usr2_with_cis_hardening,Installing
+refresh_spare_usr2 with CIS hardening>> subsection of the
+<<cis-setup.adoc#,CIS Hardening for FSL10>> document.
+
+If you would like the extra security provided by that approach without
+using a non-_root_ account on the _operational_ system, you can adjust
+that approach by making these changes in the indicated steps:
+
+. On the _operational_ system:
+
++
+
+[start=2]
+.. Skip using _visudo_ to add a line for _spare_.
+.. Skip creating the _spare_ account.
+
+. On the _spare_ system:
+
+.. Do _not_ uncomment the line `#remote_user=spare`.
+
+.. Use the `ssh-copy-id root@_operational_` command in place of the
+similar one shown.
+
+. On the _operational_ system:
+
+.. In place of the indicated change, modify the line in of the
+_/root/.ssh/authorized_keys_ for the _root_ key from your _spare_
+computer by replacing `ssh-rsa` at the start of that line with
+
++
+
++
+
+`command="rrsync -ro /usr2" ssh-rsa`
+
+.. Skip locking out the _spare_ account.
+
+.. Skip disabling password aging for the _spare_ account.
+
+====
+
 ==== Using refresh_spare_usr2
 
 . As part of a monthly backup, you would usually start a disk rotation
@@ -720,8 +756,8 @@ as _root_.
 
 An alternative is to login as a non-_root_ user either on a text
 console or by _ssh_ from another system (not the _operational_
-system). In this case, you should `*cd{nbsp}/tmp*` and then either
-promote to _root_ using _su_ or run the script with _sudo_.
+system). In this case, you should promote to _root_ using _su_ or run
+the script with _sudo_.
 
 
 . Execute:
@@ -741,10 +777,30 @@ on the systems.
 
 +
 
-CAUTION: Generally speaking, it is best to _not_ login to either the
-_spare_ or _operational_ system while the script is running, but see
-the <<note,NOTE>> below for more information.
+[CAUTION]
+====
 
+Generally speaking, it is best to _not_ login to either the _spare_ or
+_operational_ system while the script is running.
+
+If logging in on the _spare_ commuter, it is best to _not_ login to an
+account with a home directory on the _/usr2_ partition (logging in as
+_root_ on a text console is okay) or otherwise access that partition
+during the refresh.  Accounts with home directories on the spare
+system _/usr2_ partition may not be fully configured until after the
+refresh completes. As a result, some accounts that you are use to
+logging into  with _ssh_ keys may require a password until the keys
+are transferred.
+
+It is possible to use the operational system during the refresh if
+necessary, but this should be avoided if possible and activity on the
+_/usr2_ partition should be as limited as possible.  You should not
+expect any changes on the operational system _/usr2_ that occur after
+the refresh starts to be propagated to the spare system.  There may be
+some warnings that files cannot be found on the operational system if
+they were deleted before they were transferred.
+
+====
 +
 
 An email will be sent to _root_ when the refresh finishes. If your
@@ -760,44 +816,13 @@ for the message.
 
 +
 
-Alternatively, you can use the time it took previous refreshes to
-finish to estimate how log this one may take. You can examine the logs
-(before starting the refresh) in _/root/refresh_spare_usr2_logs_ to
-see how long previous refreshes took. Typically a new refresh will
-take a little longer than the most recent previous refresh. You can
-check the log for the current refresh after at least that much time
-has elapsed to verify that it has finished.
+Alternatively, you can examine the logs (before starting the refresh)
+in _/root/refresh_spare_usr2_logs_ to see how long previous refreshes
+took. When at least that much time has elapsed, you can login and can
+check the log for the current refresh to verify that it has finished.
 
 +
 
-[[note]]
-[NOTE]
-====
-
-Do not login to an account on the _spare_ system with a home directory
-on the _/usr2_ partition (logging in as _root_ on a text console is
-okay) or otherwise access that partition during the refresh.
-
-It is possible to use the _operational_ system during the refresh if
-necessary, but this should be avoided if possible and activity on the
-_/usr2_ partition should be as limited as possible.  You should not
-expect any changes on the _operational_ system _/usr2_ that occur
-after the refresh starts to be propagated to the _spare_ system.  If
-any files on the _operational_ system _/usr2_ are deleted from it
-before they could be copied, there may be error messages like:
-
-[subs="+quotes"]
-....
-tar: _file_: Cannot stat: No such file or directory
-....
-
-for those ``_file_``s and a final summary error message:
-
-  tar: Exiting with failure status due to previous errors
-
-but without other errors the refresh should still generally succeed.
-
-====
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.4 - September 2021
+Version 1.4.5 - September 2021
 
 :sectnums:
 :experimental:
@@ -691,12 +691,13 @@ _sudo_ in a regular account acceptable.  Please see the
 refresh_spare_usr2 with CIS hardening>> subsection of the
 <<cis-setup.adoc#,CIS Hardening for FSL10>> document.
 
-All the steps below must be executed as _root_ on the specified
-system.
+All the steps below must be performed as _root_ on the specified
+system. You should read all of each step or sub-step before following
+it.
 
 . On the _spare_ system:
 
-.. Install _refresh_spare_usr2_:
+.. Install _refresh_spare_usr2_. Execute:
 
   cd /usr/local/sbin
   cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
@@ -730,16 +731,7 @@ system.
 
 +
 
-.. Create and copy a key for _root_:
-
-+
-
-NOTE: If _root_ already has a key, you only need the second command
-below to copy it to the _spare_ system:
-
-+
-
-TIP: It is recommended to not set a passphrase.
+.. Create and copy a key for _root_. Execute:
 
 +
 
@@ -754,9 +746,20 @@ ssh-copy-id root@_operational_
 where `_operational_` is the alias, name, or IP of your _operational_
 system.
 
++
+
+NOTE: If _root_ already has a key, you only need the second command
+above to copy it to the _spare_ system.
+
++
+
++
+
+TIP: It is recommended to not set a passphrase.
+
 . On the _operational_ system:
 
-.. Install the _rrsync_ script:
+.. Install the _rrsync_ script. Execute:
 
 +
 
@@ -784,7 +787,7 @@ _spare_ system with:
 un-commenting the `PermitRootLogin` line and changing the second field
 from `prohibit-password` to `forced-commands-only`.
 
-... Restart `_sshd_:
+... Restart `_sshd_. Execute:
 
   systemctl restart sshd
 
@@ -800,18 +803,18 @@ IMPORTANT: Before proceeding, make sure that no one is logged into
 either system and that no processes are running on _/usr2_ on either
 system, particularly the FS.
 
-. Login on the _spare_ system on a local virtual console text terminal
-as _root_.
+. Login on the _spare_ system. The best choice for this is as _root_
+on a local virtual console text terminal.
 
 +
 
-An alternative is to login as a non-_root_ user either on a text
-console or by _ssh_ from another system (not the _operational_
-system). In this case, you should promote to _root_ using _su_ or run
-the script with _sudo_ (or _root_account_ for CIS hardened systems).
+TIP: Logging in as a non-_root_ user is acceptable. Any means can be
+used: a text console, _ssh_ from another system (preferrably not the
+_operational_ system), or the graphics X display. In these cases, you
+should promote to _root_ using _su_ (or execute the script with _sudo_
+for CIS hardened systems).
 
-
-. Execute:
+. Execute the script:
 
   refresh_spare_usr2
 
@@ -835,12 +838,6 @@ indication that it finished successfully.
 
 +
 
-If emails to _root_ are _not_ being forwarded off the system and you
-_can_ login as _root_ on a text console, you can check _root_'s email
-for the message.
-
-+
-
 Alternatively, you can examine the logs (before starting the refresh)
 in _/root/refresh_spare_usr2_logs_ to see how long previous refreshes
 took. When at least that much time has elapsed, you can login and can
@@ -857,22 +854,19 @@ _operational_ system while the script is running.
 If you do login to the _spare_ system, it is best to _not_ use an
 account with a home directory on the _/usr2_ partition (logging in as
 _root_ on a text console is okay) or otherwise access that partition
-while the script is running. Additionally, accounts with home
-directories on the spare system _/usr2_ partition may not be fully
-configured until after the refresh completes. As a result, some
-accounts that you are use to logging into with _ssh_ keys may require
-a password until the keys are transferred.
+while the script is running. In any event, activity on _/usr2_ should
+be minimized.
 
 It is possible to use the operational system during the refresh if
 necessary, but this should be avoided if possible and activity on the
-_/usr2_ partition should be as limited as possible.  You should not
-expect any changes on the operational system _/usr2_ that occur after
-the refresh starts to be propagated to the spare system. If any files
-are deleted before they can be transferred, there will be a warning
-`file has vanished: "_file_"`, for each such `_file_`, and there will
-be a summary warning that starts with `rsync warning: some files
-vanished before they could be transferred`, but without additional
-warnings or errors, the transfer should otherwise be successful.
+_/usr2_ partition should be minimized. You should not expect any
+changes on the operational system _/usr2_ that occur after the refresh
+starts to be propagated to the spare system. If any files are deleted
+before they can be transferred, there will be a warning `file has
+vanished: "_file_"`, for each such `_file_`, and there will be a
+summary warning that starts with `rsync warning: some files vanished
+before they could be transferred`, but without additional warnings or
+errors, the transfer should otherwise be successful.
 
 ====
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.7 - September 2021
+Version 1.5.0 - September 2021
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.2 - September 2021
+Version 1.4.3 - September 2021
 
 :sectnums:
 :experimental:
@@ -796,9 +796,12 @@ It is possible to use the operational system during the refresh if
 necessary, but this should be avoided if possible and activity on the
 _/usr2_ partition should be as limited as possible.  You should not
 expect any changes on the operational system _/usr2_ that occur after
-the refresh starts to be propagated to the spare system.  There may be
-some warnings that files cannot be found on the operational system if
-they were deleted before they were transferred.
+the refresh starts to be propagated to the spare system. If any files
+are deleted before they can be transferred, there will be a warning
+`file has vanished: "_file_"`, for each such `_file_`, and there will
+be a summary warning that starts with `rsync warning: some files
+vanished before they could be transferred`, but without additional
+warnings or errors, the transfer should otherwise be successful.
 
 ====
 +

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.4.3 - September 2021
+Version 1.4.4 - September 2021
 
 :sectnums:
 :experimental:
@@ -639,22 +639,20 @@ little slow.
 
 === refresh_spare_usr2
 
-NOTE: This subsection follows the FS manual font conventions.
+NOTE: This subsection, along with its subsections, follow the FS
+manual font conventions.
 
 This script is not part of RAID operations per se, but is included in
 this document for completeness. In a two system configuration
 (_operational_ and _spare_), it is used to make a copy of the
 _operational_ system's _/usr2_ partition on the _spare_ system.
 Normally this partition holds all the operational FS programs and
-data. The script can be found in _/root/fsl10/RAID_. Full
-instructions for its installation are included in the script. The
-script will give a warning about its use and prompt for permission to
-proceed when it it is run.
+data.
 
 A full description of the features of the script are available from
 the `*refresh_spare_usr2{nbsp}-h*` output.
 
-IMPORTANT: It should be installed on the _spare_ system _only_.
+IMPORTANT: This script should be installed on the _spare_ system _only_.
 
 [TIP]
 ====
@@ -679,10 +677,6 @@ shelf disk a deeper back-up than the _spare_ system RAID disks.
 
 ==== Installing refresh_spare_usr2
 
-Instructions for customizing _refresh_spare_usr2_ for your system are included
-in comments in the script.  If it has not been customized yet, it will print
-a message indicating that this is needed and exit.
-
 WARNING: For this script to work most usefully, the _operational_ and
 _spare_ systems should have the same set-up including particularly the
 same user accounts with same UIDs and GIDs in parallel for all
@@ -690,40 +684,95 @@ accounts, particularly for those that have home directories on
 _/usr2_, as well as other OS set-up information the FS may depend on
 such as _/etc/hosts_ and _/etc/ntp.conf_.
 
-[TIP]
-====
-
-If you are unable to use login to the _operational_ system with _ssh_
-keys from the _spare_ system, you may be able to use the approach
-given in the
+TIP: If you are unwilling or unable to use the force command approach
+below for the _root_ account, you may find the approach of using
+_sudo_ in a regular account acceptable.  Please see the
 <<cis-setup.adoc#_installing_refresh_spare_usr2_with_cis_hardening,Installing
 refresh_spare_usr2 with CIS hardening>> subsection of the
 <<cis-setup.adoc#,CIS Hardening for FSL10>> document.
 
-If you would like the extra security provided by that approach without
-using a non-_root_ account on the _operational_ system, you can adjust
-that approach by making these changes in the indicated steps:
-
-. On the _operational_ system:
-
-+
-
-[start=2]
-.. Skip using _visudo_ to add a line for _spare_.
-.. Skip creating the _spare_ account.
+All the steps below must be executed as _root_ on the specified
+system.
 
 . On the _spare_ system:
 
-.. Do _not_ uncomment the line `#remote_user=spare`.
+.. Install _refresh_spare_usr2_:
 
-.. Use the `ssh-copy-id root@_operational_` command in place of the
-similar one shown.
+  cd /usr/local/sbin
+  cp -a /root/fsl10/RAID/refresh_spare_usr2 refresh_spare_usr2
+  chown root.root refresh_spare_usr2
+  chmod a+r,u+wx,go-wx refresh_spare_usr2
+
+.. Customize _refresh_spare_usr2_, following the directions in the
+comments in the script:
+
+... Comment-out the lines (add leading ``#``s):
+
++
+
+....
+echo "This script must be customized before use.  See script for details."
+exit 1
+....
+
+... Change the `operational` in the line:
+
++
+
+....
+remote_node=operational
+....
+
++
+
+to the alias (preferred), FQDN, or IP address of your _operational_
+system.
+
++
+
+.. Create and copy a key for _root_:
+
++
+
+NOTE: If _root_ already has a key, you only need the second command
+below to copy it to the _spare_ system:
+
++
+
+TIP: It is recommended to not set a passphrase.
+
++
+
+[subs="+quotes"]
+----
+ssh-keygen
+ssh-copy-id root@_operational_
+----
+
++
+
+where `_operational_` is the alias, name, or IP of your _operational_
+system.
 
 . On the _operational_ system:
 
-.. In place of the indicated change, modify the line in of the
-_/root/.ssh/authorized_keys_ for the _root_ key from your _spare_
-computer by replacing `ssh-rsa` at the start of that line with
+.. Install the _rrsync_ script:
+
++
+
+....
+gunzip -c /usr/share/doc/rsync/scripts/rrsync.gz >/usr/local/bin/rrsync
+ln -s /usr/local/bin/rrsync /usr/bin/rrsync
+chmod u+x,go-x /usr/local/bin/rrsync
+....
+
+.. Set the _root_ account to only allow a _forced command_ with _ssh_:
+
+... Replace the `ssh-rsa` at the start of the line (probably the only
+one) in _~root/.ssh/authorized_keys_ for the _root_ account on the
+_spare_ system with:
+
++
 
 +
 
@@ -731,11 +780,13 @@ computer by replacing `ssh-rsa` at the start of that line with
 
 `command="rrsync -ro /usr2" ssh-rsa`
 
-.. Skip locking out the _spare_ account.
+... Set _sshd_ to only allowed forced commands for _root_ by
+un-commenting the `PermitRootLogin` line and changing the second field
+from `prohibit-password` to `forced-commands-only`.
 
-.. Skip disabling password aging for the _spare_ account.
+... Restart `_sshd_:
 
-====
+  systemctl restart sshd
 
 ==== Using refresh_spare_usr2
 
@@ -777,35 +828,6 @@ resuming other activities on the systems.
 
 +
 
-[CAUTION]
-====
-
-Generally speaking, it is best to _not_ login to either the _spare_ or
-_operational_ system while the script is running.
-
-If you do login to the _spare_ commuter, it is best to _not_ use an
-account with a home directory on the _/usr2_ partition (logging in as
-_root_ on a text console is okay) or otherwise access that partition
-while the script is running. Accounts with home directories on the
-spare system _/usr2_ partition may not be fully configured until after
-the refresh completes. As a result, some accounts that you are use to
-logging into with _ssh_ keys may require a password until the keys are
-transferred.
-
-It is possible to use the operational system during the refresh if
-necessary, but this should be avoided if possible and activity on the
-_/usr2_ partition should be as limited as possible.  You should not
-expect any changes on the operational system _/usr2_ that occur after
-the refresh starts to be propagated to the spare system. If any files
-are deleted before they can be transferred, there will be a warning
-`file has vanished: "_file_"`, for each such `_file_`, and there will
-be a summary warning that starts with `rsync warning: some files
-vanished before they could be transferred`, but without additional
-warnings or errors, the transfer should otherwise be successful.
-
-====
-+
-
 An email will be sent to _root_ when the refresh finishes. If your
 email to _root_ is being forwarded to a mailbox off the system, you
 can use receipt of that message (and that it shows no errors) as the
@@ -826,6 +848,33 @@ check the log for the current refresh to verify that it has finished.
 
 +
 
+[CAUTION]
+====
+
+Generally speaking, it is best to _not_ login to either the _spare_ or
+_operational_ system while the script is running.
+
+If you do login to the _spare_ system, it is best to _not_ use an
+account with a home directory on the _/usr2_ partition (logging in as
+_root_ on a text console is okay) or otherwise access that partition
+while the script is running. Additionally, accounts with home
+directories on the spare system _/usr2_ partition may not be fully
+configured until after the refresh completes. As a result, some
+accounts that you are use to logging into with _ssh_ keys may require
+a password until the keys are transferred.
+
+It is possible to use the operational system during the refresh if
+necessary, but this should be avoided if possible and activity on the
+_/usr2_ partition should be as limited as possible.  You should not
+expect any changes on the operational system _/usr2_ that occur after
+the refresh starts to be propagated to the spare system. If any files
+are deleted before they can be transferred, there will be a warning
+`file has vanished: "_file_"`, for each such `_file_`, and there will
+be a summary warning that starts with `rsync warning: some files
+vanished before they could be transferred`, but without additional
+warnings or errors, the transfer should otherwise be successful.
+
+====
 
 . If it finished with no problems, you can reboot as soon as is
 convenient. You may reboot even if the RAID is recovering, but you can

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.5.0 - September 2021
+Version 1.5.0 - October 2021
 
 :sectnums:
 :experimental:

--- a/raid.adoc
+++ b/raid.adoc
@@ -684,9 +684,10 @@ accounts, particularly for those that have home directories on
 _/usr2_, as well as other OS set-up information the FS may depend on
 such as _/etc/hosts_ and _/etc/ntp.conf_.
 
-TIP: If you are unwilling or unable to use the force command approach
-below for the _root_ account, you may find the approach of using
-_sudo_ in a regular account acceptable.  Please see the
+TIP: If you are unwilling or unable to use the _forced command_
+approach below for the _root_ account, you may find the approach of
+using _sudo_ in a regular account a usable alternative. For details on
+that approach, please see the
 <<cis-setup.adoc#_installing_refresh_spare_usr2_with_cis_hardening,Installing
 refresh_spare_usr2 with CIS hardening>> subsection of the
 <<cis-setup.adoc#,CIS Hardening for FSL10>> document.
@@ -783,6 +784,20 @@ _spare_ system with:
 
 `command="rrsync -ro /usr2" ssh-rsa`
 
++
+
++
+
++
+
+TIP: If your _spare_ system is registered with DNS, you can provide
+some additional security by adding ``from="__node__" `` {nbsp}(note
+the trailing space) at the start of the line, where `__node__` is the
+FQDN or IP address of the _spare_ system.  It may be necessary to
+provide the FQDN, IP address, and/or alias of the _spare_ system in a
+comma separated list in place of  `__node__` to get reliable
+operation.
+
 ... Set _sshd_ to only allowed forced commands for _root_ by
 un-commenting the `PermitRootLogin` line and changing the second field
 from `prohibit-password` to `forced-commands-only`.
@@ -809,9 +824,9 @@ on a local virtual console text terminal.
 +
 
 TIP: Logging in as a non-_root_ user is acceptable. Any means can be
-used: a text console, _ssh_ from another system (preferrably not the
+used: a text console, _ssh_ from another system (preferably not the
 _operational_ system), or the graphics X display. In these cases, you
-should promote to _root_ using _su_ (or execute the script with _sudo_
+must promote to _root_ using _su_ (or execute the script with _sudo_
 for CIS hardened systems).
 
 . Execute the script:
@@ -831,17 +846,18 @@ resuming other activities on the systems.
 
 +
 
-An email will be sent to _root_ when the refresh finishes. If your
+An email will be sent to _root_ when the script finishes. If your
 email to _root_ is being forwarded to a mailbox off the system, you
 can use receipt of that message (and that it shows no errors) as the
 indication that it finished successfully.
 
 +
 
-Alternatively, you can examine the logs (before starting the refresh)
-in _/root/refresh_spare_usr2_logs_ to see how long previous refreshes
-took. When at least that much time has elapsed, you can login and can
-check the log for the current refresh to verify that it has finished.
+Alternatively, you can examine the logs (before starting the script)
+in _/root/refresh_spare_usr2_logs_ to see how long previous script
+uses took. When at least that much time has elapsed, you can login
+and can check the log for the current script use to verify that it has
+finished.
 
 +
 
@@ -849,7 +865,11 @@ check the log for the current refresh to verify that it has finished.
 ====
 
 Generally speaking, it is best to _not_ login to either the _spare_ or
-_operational_ system while the script is running.
+_operational_ system while the script is running. Under normal
+circumstances the script should run quickly enough that this does not
+cause a significant burden. If it is necessary to login to either
+system, the following paragraphs in this *CAUTION* cover the relevant
+considerations.
 
 If you do login to the _spare_ system, it is best to _not_ use an
 account with a home directory on the _/usr2_ partition (logging in as
@@ -857,23 +877,29 @@ _root_ on a text console is okay) or otherwise access that partition
 while the script is running. In any event, activity on _/usr2_ should
 be minimized.
 
-It is possible to use the operational system during the refresh if
-necessary, but this should be avoided if possible and activity on the
-_/usr2_ partition should be minimized. You should not expect any
-changes on the operational system _/usr2_ that occur after the refresh
-starts to be propagated to the spare system. If any files are deleted
-before they can be transferred, there will be a warning `file has
-vanished: "_file_"`, for each such `_file_`, and there will be a
-summary warning that starts with `rsync warning: some files vanished
-before they could be transferred`, but without additional warnings or
-errors, the transfer should otherwise be successful.
+It is possible to use the _operational_ system while the script is
+running if necessary, but this should be avoided if possible and
+activity on the _/usr2_ partition should be minimized. You should not
+expect any changes on the _operational_ system _/usr2_ that occur
+after the script starts to be propagated to the _spare_ system. If any
+files are deleted before they can be transferred, there will be a
+warning `file has vanished: "_file_"`, for each such `_file_`, and
+there will be a summary warning that starts with `rsync warning: some
+files vanished before they could be transferred`, but without
+additional warnings or errors, the transfer should otherwise be
+successful.
+
+In case you have logged into either system while the script is
+running, you can touch-up the copy on the _spare_ system, by rerunning
+the script after logging out.
 
 ====
 
-. If it finished with no problems, you can reboot as soon as is
-convenient. You may reboot even if the RAID is recovering, but you can
-wait until the recovery is complete. The only requirement is to reboot
-before the FS is run again on the _spare_ system.
+. If the script finished with no problems, you can reboot the _spare_
+system as soon as is convenient. You may reboot even if the RAID is
+recovering, but you can wait until the recovery is complete. The only
+requirement is to reboot before the FS is run again on the _spare_
+system.
 
 == Multiple computer set-up
 


### PR DESCRIPTION
@jfhquick suggested switching to _rsync_ to reduce the time required when _/usr2_ contains a lot of data. He also suggested that using _rrsync_ on the operational system may be a way to implement this with CIS hardening. These were both excellent suggestions. This PR is a first draft at making them work.

Summary of changes:

- Use _rsync_ in place of _tar_-based transfer.
- Move use of _mke2fs_ to option `-I`.
- Add option `-i` to trigger _rsync_ to transfer all files.
- Use _rrsync_ for CIS hardening.
- Make options that aren't for normal use uppercase.
- Update documents to agree.

These changes completely reorient the running of the script, simplifying it, and making routine use the same for both regular and CIS users. Special restrictions for using it are still required for the `-I` option.

There is some question whether the `-I` option is needed but perhaps it is worth keeping for possible recovery for some usual cases.  We can have it available as an option anyway. Likewise the `-i` option has limited utility, but may be useful to overcome possible issues with the modification time based quick check _rsync_ uses without requiring _mke2fs_.

I didn't see a way to make a good progress bar for foreground mode. Using `--info=progress2 --no-i-r` works pretty well, but there was no way to direct it only to the terminal, so it could make the log file unreasonably large. Instead, I used _pv_ in line mode to count the number of files and provide elapsed time. The resulting output may appear uneven because some files may be very large. There is no percentage of completion or ETA, but at least there is some feedback that the transfer is running.

Drafts of the updated sections in the documents can be found at [refresh_spare_usr2](https://nvi-inc.github.io/fsl10/draft_raid.html#_refresh_spare_usr2) and [Installing refresh_spare_usr2 with CIS hardening](https://nvi-inc.github.io/fsl10/draft_cis-setup.html#_installing_refresh_spare_usr2_with_cis_hardening). The embedded inks between the documents do not work.

The nominal plan is to install and test this in the field Sept 24.