### PR TITLE
Add raid-events script

### DIFF
--- a/RAID/raid-events
+++ b/RAID/raid-events
@@ -1,0 +1,93 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 NVI, Inc.
+#
+# This file is part of FSL10 Linux distribution.
+# (see http://github.com/nvi-inc/fsl10).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# For systems with GPT LVM RAID arrays, copies the partition table onto
+# the second disk (if missing), rebuilds the boot sector and adds the RAID
+# partition back into the array as a spare to be rebuilt.
+
+get_mdstat() {
+   local -n arr=$1
+   mapfile arr < <(cat /proc/mdstat;echo;lsblk --nodeps -o NAME,HCTL,MODEL,SIZE,SERIAL /dev/sd*[!0-9])
+}
+
+send_mail () {
+subject=$1
+shift
+echo "$@" | /usr/bin/mail -s "$subject" root &
+}
+
+event=$1
+device=$2
+component=$3
+
+#debug
+#get_mdstat lines
+#send_mail "raid-events: $event on $device component: $component" "${lines[@]}"
+
+if [[ "$event" != RebuildStarted && "$event" != RebuildFinished ]]; then
+    exit
+fi
+
+rebuild_file=/tmp/.rebuild_active
+check_file=/tmp/.check_active
+
+for run in {1..3}; do
+    if [[ "$run" != 1 ]]; then
+        sleep 1
+    fi
+    rebuild=
+    check=
+    degraded=OKAY
+    get_mdstat lines
+
+# debug
+#    send_mail "Try $run" "${lines[@]}"
+
+    for line in "${lines[@]}" ; do
+        if [[ "$line" == *recovery* ]]; then
+             rebuild=1
+        fi
+        if [[ "$line" == *check* ]]; then
+             check=1
+        fi
+        if [[ "$line" == *\[*_*\]* ]]; then
+             degraded="DEGRADED"
+        fi
+    done
+
+    if [[ -n "$rebuild" && ! -f "$rebuild_file" ]]; then
+        send_mail "Rebuild Running on $device" "${lines[@]}"
+        touch "$rebuild_file"
+        exit
+    elif [[ -z "$rebuild" && -f "$rebuild_file" ]]; then
+        send_mail "Rebuild Ended $degraded on $device" "${lines[@]}"
+        rm -f "$rebuild_file"
+        exit
+    elif [[ -n "$check" && ! -f "$check_file" ]]; then
+        send_mail "Check Running on $device" "${lines[@]}"
+        touch "$check_file"
+        exit
+    elif [[ -z "$check" && -f "$check_file" ]]; then
+        send_mail "Check Ended $degraded on $device" "${lines[@]}"
+        rm -f "$check_file"
+        exit
+    fi
+done

--- a/cis-setup.adoc
+++ b/cis-setup.adoc
@@ -20,7 +20,7 @@
 
 = CIS hardening for FSL10
 Dave Horsley and Ed Himwich
-Version 1.5.1 - December 2021
+Version 1.6.0 - January 2022
 
 :experimental:
 :toc:

--- a/installation.adoc
+++ b/installation.adoc
@@ -18,9 +18,11 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //
 
+:doctype: book
+
 = FS Linux 10 Installation Guide
 J.F.H. Quick, D.E. Horsley, and W.E. Himwich
-Version 1.5.2 - December 2021
+Version 1.6.0 - January 2022
 
 :sectnums:
 :experimental:
@@ -919,354 +921,20 @@ When the syncing is complete, you can repeat the process of the
 previous sub-section and this sub-section if you have a third disk that needs
 to be set-up.
 
-== Managing security updates
+=== Consider additional customizations
 
-It is strongly recommended that you use the weekly _cron_ update
-download (the "`weekly _cron_ job`") as configured according to the `Window 2` sub-section in
-the <<_fsadapt>> section above. This will keep you informed of the
-available updates on a weekly basis.
+Please refer to the appendix <<Additional Setup Items>> below for
+customizations that your system may need or that you may find useful.
 
-It is also recommended that you remove _anacron_ as described in the
-<<_remove_anacron_package>> section below. This will cause the updates
-to always be downloaded at what should be innocuous time, early Sunday
-morning (but this can be adjusted if need be).
+[appendix]
 
-NOTE: An optional method for identifying available  updates without using
-the weekly _cron_ job is described below in the section
-<<Manually checking for updates>>.
+== Additional Setup Items
 
-=== Installing updates (Upgrading)
-
-TIP: It is recommended that a disk rotation be performed before any
-update is installed. This will make recovery much easier if a problem with the
-update is discovered.  Please see the FSL10 Raid document section
-<<raid.adoc#_recoverable_testing,Recoverable testing>> for a
-streamlined method to manage testing of updates.
-
-If updates are needed, the weekly _cron_ job will send a message to _root_
-(or whoever e-mail to _root_ is aliased to, typically _oper_) with
-instructions on how to install the updates. You can choose a
-convenient time, when not in (or about to start) operations, to install
-the updates and test the system.
-
-IMPORTANT: The weekly _cron_ job
-message will include instructions for handling a kernel update if one is available.
- See the <<Kernel updates>> sub-section below for additional
-considerations for kernel updates.
-
-The commands for installing the updates given by the message are (note
-        the use of _apt_ instead of _apt-get_):
-
-   apt upgrade
-
-Enter `*y*` to confirm as needed. Then
-
-   apt clean
-
-If the weekly _cron_ job was installed according to the <<_fsadapt>>
-section above (for `Window 2`), the first of these commands (with
-        `upgrade`) will show if any NEWS items are included in the
-update. If there are, they will be displayed by a paging program at the beginning of the upgrade and
-you will be given an extra chance to abort before installing.
-
-NOTE: NEWS items are, rarely occurring, announcements that may
-indicate additional steps are needed beyond the standard installation
-process. If any NEWS items are displayed, you should consider
-whether these will effect your system and how to handle them before
-installing. The first command above (with `upgrade`) will also cause e-mails
-to be sent to _root_ with the NEWS information.
-
-=== Kernel updates
-
-WARNING: Kernel updates require extra care and testing. If you are
-using a RAID, you should consider using the
-<<raid.adoc#_recoverable_testing,Recoverable testing>>
-procedure to give more, and easier, options for recovery in case there
-is a problem.  That procedure contains special instructions for kernel
-update testing.
-
-If there is a kernel update available, the weekly _cron_ job output
-will include a warning at the end with additional instructions
-depending on which type is available.  There are two types of kernel
-updates:
-
-. ABI updates, e.g., from _4.9.0-11-amd64_ to
-   _4.9.0-12-amd64_ (with _11_ and _12_ being the ABI versions), which change the kernel ABI (Application Binary
-           Interface). The warning for this case is:
-
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    NB: The Linux kernel image is one of the packages due to be upgraded.
-    NB: (The kernal ABI has changed as per the linux-latest source package above
-    NB:  so all out-of-tree modules WILL NEED TO BE REBUILT after you REBOOT.)
-    NB: Please allow _extra time_ for TESTING after the upgrade.
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-. Non-ABI updates, which update the kernel, but do not change the
-ABI. The warning for this case is:
-
-
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    NB: The Linux kernel image is one of the packages due to be upgraded.
-    NB: (Upgrading will OVERWRITE the running kernel and require you to REBOOT!)
-    NB: Please allow _extra time_ for TESTING after the upgrade.
-    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-Be sure to allow time to follow the instructions when planning to
-install these updates.  As described in the ABI update warning, you
-will need to rebuild any out-of-tree modules after rebooting for that
-case. This is discussed in the <<Updating out-of-tree modules>>
-sub-section below.
-
-CAUTION: In extreme circumstances, an ABI (but _not_ a non-ABI) kernel
-update can be deferred to a later date when more extensive testing can
-be performed by using _apt-get_ in place of _apt_ in the instructions
-for installing the update. This works because an ABI update involves
-new packages. The  _apt-get_ command will install the updates for existing
-packages, but it will not install the new packages. While this method can
-be used to install the other updates, it is not recommended since
-there are presumably security patches needed for the kernel and they
-are not being installed in this case.
-
-==== Updating out-of-tree modules
-
-When a ABI update is installed, it will be necessary to update any,
-so-called, _out-of-tree_ modules that use the kernel ABI. This must be
-done _after_ rebooting with the new kernel installed.
-
-For a normal FSL10 installations, unless you have installed other
-out-of-tree modules, the only module that needs to be rebuilt is the
-GPIB driver (if it is installed).  You will need to recompile it (usually using _fsadapt_,
-        `Window 2`, `config_gpib` only) _after_ the initial reboot
-        and then (to keep these instructions simple) reboot _again_.
-
-If you have installed other out-of-tree modules (e.g., you use a
-special driver for some of your NICs), you will need to update them
-appropriately _after_ the initial reboot and then (to keep these
-        instructions simple) reboot _again_.
-
-===  Recovery from a failed update
-
-If an update fails, e.g., an updated kernel fails to boot or another problem is discovered,
-you can recover as described in FSL10 RAID document
-<<raid.adoc#_recoverable_testing,Recoverable testing>>
-section, if you were following that method, or from a shelf disk
-according to the FSL10 RAID document <<raid.adoc#_recover_from_a_shelf_disk,Recover from
-a shelf disk>> section if not and you have a good shelf disk.
-
-==== Additional recovery option for a failed ABI kernel update
-
-For a ABI update that has failed, it is also possible to try to use
-the previous kernel on the current system. For a single boot, use the
-`Advanced` option in the _grub_ menu at boot and then select the
-previous kernel. You can change back permanently to the previous
-kernel by purging the new kernel and its headers. To do this, use:
-
-    dpkg -l|grep linux-image
-    dpkg -l|grep linux-headers
-
-to determine the ABI version to be removed. For example, for the
-first command above, you may get:
-
-    linux-image-4.9.0-11-amd64
-    linux-image-4.9.0-12-amd64
-
-The package with _12_ would be the later version that should be purged:
-
-    apt-get purge linux-image-4.9.0-12-amd64
-
-Likewise with the linux-headers. For example, for the _12_ ABI
-version, there will be two packages you should purge:
-
-    linux-headers-4.9.0-12-amd64
-    linux-headers-4.9.0-12-common
-
-=== Manually checking for updates
-
-If you do not use the weekly _cron_ job to check for updates, or if
-you want to make sure you have the very latest updates when you
-install them, you can run the distributed copy of the weekly update
-script manually to check for updates:
-
-    /root/fsl10/etc_cron.weekly_apt-show-upgradeable 
-
-If there is no output, there are no updates to install.
-
-If there is output, there are updates to install.
-You can install them by following the installation procedure in
-sub-section <<Installing updates (Upgrading)>> above, except you will use the
-instructions from the output of the script above instead of from the
-weekly _cron_ job (the outputs should be equivalent for the same set of
-        updates). Additionally, please read the following *NOTE*.
-
-NOTE: If the weekly _cron_ job has not been installed, you may not get a
-    display of NEWS items and a chance to abort when you install the updates. You
-    can use the method below with the `--which=news` parameter to
-    check for NEWS before installing an update.
-
-Any NEWS items will be included in the script output along with the
-packages to be updated. If you would like to see any NEWS items more
-distinctly after the previous command and before installing the
-updates, you can run the script again using the `--which=news` option:
-
-    /root/fsl10/etc_cron.weekly_apt-show-upgradeable --which=news
-
-If there are updates available and no NEWS items, you will only get
-the installation instructions.
-
-You can use this second form of running the script to check for
-updates initially, if you do not need to review which updates are
-available (you will still get warnings about kernel updates). As
-usual, you will see no output at all if there are no updates
-available.
-
-=== End of security updates
-
-When support for _stretch_ ends, currently expected in June 2022,
-there will be no more security updates.  At that time, the existing
-packages will be migrated to the Debian archive site. This will be
-visible in the output from the weekly _cron_ job script as errors that
-the packages files can't be found. Two steps are needed at that time:
-
-. If you have been using the weekly _cron_ job, it should be deleted:
-+
-    rm /etc/cron.weekly/apt-show-upgradeable
-+
-(you may need to answer `*y*` to confirm)
-
-. Change the _/etc/apt/sources.list_ file to point to the archive
-site. Although there will be no more security updates, this will enable
-downloading of additional packages if they are needed. The new lines that
-should replace the corresponding lines are:
-+
-   deb http://archive.debian.org/debian/ stretch main contrib non-free
-   deb http://archive.debian.org/debian-security stretch/updates main contrib non-free
-   deb http://archive.debian.org/debian-volatile stretch/volatile main contrib non-free
-+
-And if you are using `deb-src` lines:
-+
-   deb-src http://archive.debian.org/debian/ stretch main contrib non-free
-   deb-src http://archive.debian.org/debian-security stretch/updates main contrib non-free
-   deb-src http://archive.debian.org/debian-volatile stretch/volatile main contrib non-free
-+
-Otherwise the `deb-src` lines can be commented out (with a leading `#`).
-+
-In addition, if you want to install packages from more recent
-distributions that have been backported to _stretch_ you can add:
-+
-  deb http://archive.debian.org/debian-backports stretch-backports main contrib non-free
-+
-However, the "`backports`" are not normally needed.
-+
-Lastly, update the index files:
-+
-    apt-get update
-+
-This may generate an error about a `Release` file having expired, but that is benign.
-
-== Rescue mode
-
-Rescue mode is useful for repairing some problems that prevent booting
-and/or logging in.
-
-NOTE: If your computer's _setup_ utility is locked with a password, you
-may need that password to select booting from your installation media.
-
-NOTE: You should provide suitable values for your system when a
-specific value is required. Values that agree with the FSL10 install
-described in this document (or reasonable defaults) are shown in parentheses.
- 
-. Boot from installation media
-. Select `Advanced options ...`
-. Select `... Rescue mode`
-+
-
-[NOTE]
-====
-
-You could instead add parameters to the boot line (by entering kbd:[e] for UEFI or
-kbd:[Tab] for BIOS on the `... Rescue mode` line instead), following the
-directions in the <<Set boot options and boot installer>> section above.
-This is not necessary nor usually helpful, but if you use this approach the
-most useful parameters are probably `netcfg/disable_dhcp=true` and/or
-`time/zone=UTC`. Use of added parameters will change the dialogue
-below.
-
-====
-
-. Select Language (`English`)
-. Select Location (`United States`)
-. Select Keymap (`American English`)
-. Network configuration
-+
-
-If no network is currently available (or you know that you do not need it
-for the rescue), simply press kbd:[Enter] when DHCP autoconfiguration starts and
-press kbd:[Enter] again for the resulting `Network autoconfiguration failed`
-message. Thereafter select `Do not configure the network at this time` and
-enter in the machine's hostname when prompted before continuing below.
-
-+
-
-If the DHCP autoconfiguration succeeds before you can stop it, you may
-as well confirm the hostname and domainname and continue with the
-network anyway, since you never know when it might prove useful.
-(However, if you want to make sure you don't use the network, you can
- select `Go Back` and press kbd:[Enter] for the resulting `Network
- autoconfiguration failed` message.  Thereafter select `Do not
- configure the network at this time` and enter in the machine's
- hostname when prompted before continuing below.)
-
-
-+
-
-Otherwise if the DHCP autoconfiguration fails and you want to use the
-network, press kbd:[Enter] for the resulting `Network autoconfiguration
-failed` message. You can then select the appropriate option, most
-likely `Configure network manually` and give appropriate responses to the
-prompts, ultimately continuing below.
-
-. Select time zone (`Eastern`)
-+
-
-NOTE: The selected time zone will have no effect on the timestamps
-stored on the disk for any changes you may make, but will affect the displayed times you see.
-
-. Select `Assemble RAID array`
-. Press kbd:[Space] on `Automatic`
-+
-Press kbd:[Enter] to continue
-
-. Select your root file system (_/dev/vg0/root_)
-. Select `Yes` to mount separate _/boot_ partition (_/boot_), unless it is corrupt
-. Select `Yes` to mount separate _/boot/efi_ partition (_/boot/efi_), unless it is corrupt
-. Select _Execute a shell in /dev/vg0/root_ (or whatever your root file system is)
-. Select `Continue` to enter rescue mode
-. Use whatever commands are needed for your repair
-+
-
-[NOTE]
-====
-If you need to use the network, DNS does not appear to work by
-default in recovery mode. Use of explicit IP addresses does work. If
-you need to use DNS, you can make it functional by deleting the symbolic
-link _/etc/resolv.conf_ and creating it as a normal file with the
-nameserver information you want, e.g.:
-
-    rm /etc/resolv.conf
-    cat >>/etc/resolv.conf <<EOF
-    nameserver 8.8.8.8
-    EOF
-====
-
-. Use the _exit_ command to exit when done
-. Select `Reboot the system`
-. "`Bob's your uncle`" (i.e., you are done!)
-
-== Optional Items
-
-This section covers several customizations that may be helpful
-depending on the requirements for the system. All actions in this
-section require _root_ permissions.
+This appendix covers several customizations that may be helpful
+depending on the requirements for a system. It serves as a reference
+for how to make these changes, but can also be helpful as a checklist
+when setting up a new system. All actions in this section require
+_root_ permissions.
 
 === Additional security and CIS Benchmarks
 
@@ -1518,7 +1186,7 @@ apt-get purge anacron
 The following tersely summarizes some _ufw_ settings that may be useful:
 
 ....
-#SSH 
+#SSH
 ufw allow OpenSSH
 #NTP
 ufw allow ntp
@@ -1738,9 +1406,9 @@ The output might look like:
 ....
 Screen 0: minimum 320 x 200, current 1920 x 1200, maximum 1920 x 2048
 VGA-1 connected primary 1920x1200+0+0 (normal left inverted right x axis y axis) 0mm x 0mm
-   1024x768      60.00  
-   800x600       60.32    56.25  
-   640x480       59.94  
+   1024x768      60.00
+   800x600       60.32    56.25
+   640x480       59.94
   1920x1200 (0x42) 154.000MHz +HSync -VSync
         h: width  1920 start 1968 end 2000 total 2080 skew    0 clock  74.04KHz
         v: height 1200 start 1203 end 1209 total 1235           clock  59.95Hz
@@ -1963,3 +1631,383 @@ Some printers will work with an `AppSocket/HP JetDirect` connection of the form 
 default, then from the `Administration` drop down: `Set As Server Default`).
 
 . Quit _firefox_
+
+=== NTP configuration
+
+For good performance with NTP, please follow the recommendations in
+_/usr2/fs/misc/ntp.txt_.
+
+Additionally, to make the `ntpq -c pe` output more readable for local
+devices, you can adjust the contents of _/etc/hosts_. The local
+devices should be listed in the file, but use a nickname (15
+characters or less) that is meaningful locally in place of the
+canonical name (the first name after the IP address). The canonical
+name can be listed after the nickname.
+
+=== Add raid-events scripts
+
+If your system is using a RAID configuration, you may want to install
+the _raid-events_ script. The script provides email notifications of
+when Rebuilds (and array checks) start and end. For full details on
+the script and installation instructions, please see the
+<<raid.adoc#_raid_events,raid-events>> sub-section in the
+<<raid.adoc#_script_descriptions,Script descriptions>> section of the
+<<raid.adoc#,RAID Notes for FSL 10>> document.
+
+=== Add refresh_spare_usr2
+
+If you are using two systems, an _operational_ and a _spare_, you may
+want to install the _refresh_spare_usr2_ script. The script can be
+used to backup the _/usr2_ partition on the _operational_ system to
+the _spare_ system. For full details on the script and installation
+instructions, please see the
+<<raid.adoc#_refresh_spare_usr2,refresh_spare_usr2>> sub-section in
+the <<raid.adoc#_script_descriptions,Script descriptions>> section of
+the <<raid.adoc#,RAID Notes for FSL 10>> document.
+
+[appendix]
+
+== Managing Security Updates
+
+It is strongly recommended that you use the weekly _cron_ update
+download (the "`weekly _cron_ job`") as configured according to the `Window 2` sub-section in
+the <<_fsadapt>> section above. This will keep you informed of the
+available updates on a weekly basis.
+
+It is also recommended that you remove _anacron_ as described in the
+<<_remove_anacron_package>> section below. This will cause the updates
+to always be downloaded at what should be innocuous time, early Sunday
+morning (but this can be adjusted if need be).
+
+NOTE: An optional method for identifying available  updates without using
+the weekly _cron_ job is described below in the section
+<<Manually checking for updates>>.
+
+=== Installing updates (Upgrading)
+
+TIP: It is recommended that a disk rotation be performed before any
+update is installed. This will make recovery much easier if a problem with the
+update is discovered.  Please see the FSL10 Raid document section
+<<raid.adoc#_recoverable_testing,Recoverable testing>> for a
+streamlined method to manage testing of updates.
+
+If updates are needed, the weekly _cron_ job will send a message to _root_
+(or whoever e-mail to _root_ is aliased to, typically _oper_) with
+instructions on how to install the updates. You can choose a
+convenient time, when not in (or about to start) operations, to install
+the updates and test the system.
+
+IMPORTANT: The weekly _cron_ job
+message will include instructions for handling a kernel update if one is available.
+ See the <<Kernel updates>> sub-section below for additional
+considerations for kernel updates.
+
+The commands for installing the updates given by the message are (note
+        the use of _apt_ instead of _apt-get_):
+
+   apt upgrade
+
+Enter `*y*` to confirm as needed. Then
+
+   apt clean
+
+If the weekly _cron_ job was installed according to the <<_fsadapt>>
+section above (for `Window 2`), the first of these commands (with
+        `upgrade`) will show if any NEWS items are included in the
+update. If there are, they will be displayed by a paging program at the beginning of the upgrade and
+you will be given an extra chance to abort before installing.
+
+NOTE: NEWS items are, rarely occurring, announcements that may
+indicate additional steps are needed beyond the standard installation
+process. If any NEWS items are displayed, you should consider
+whether these will effect your system and how to handle them before
+installing. The first command above (with `upgrade`) will also cause e-mails
+to be sent to _root_ with the NEWS information.
+
+=== Kernel updates
+
+WARNING: Kernel updates require extra care and testing. If you are
+using a RAID, you should consider using the
+<<raid.adoc#_recoverable_testing,Recoverable testing>>
+procedure to give more, and easier, options for recovery in case there
+is a problem.  That procedure contains special instructions for kernel
+update testing.
+
+If there is a kernel update available, the weekly _cron_ job output
+will include a warning at the end with additional instructions
+depending on which type is available.  There are two types of kernel
+updates:
+
+. ABI updates, e.g., from _4.9.0-11-amd64_ to
+   _4.9.0-12-amd64_ (with _11_ and _12_ being the ABI versions), which change the kernel ABI (Application Binary
+           Interface). The warning for this case is:
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    NB: The Linux kernel image is one of the packages due to be upgraded.
+    NB: (The kernal ABI has changed as per the linux-latest source package above
+    NB:  so all out-of-tree modules WILL NEED TO BE REBUILT after you REBOOT.)
+    NB: Please allow _extra time_ for TESTING after the upgrade.
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+. Non-ABI updates, which update the kernel, but do not change the
+ABI. The warning for this case is:
+
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    NB: The Linux kernel image is one of the packages due to be upgraded.
+    NB: (Upgrading will OVERWRITE the running kernel and require you to REBOOT!)
+    NB: Please allow _extra time_ for TESTING after the upgrade.
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+Be sure to allow time to follow the instructions when planning to
+install these updates.  As described in the ABI update warning, you
+will need to rebuild any out-of-tree modules after rebooting for that
+case. This is discussed in the <<Updating out-of-tree modules>>
+sub-section below.
+
+CAUTION: In extreme circumstances, an ABI (but _not_ a non-ABI) kernel
+update can be deferred to a later date when more extensive testing can
+be performed by using _apt-get_ in place of _apt_ in the instructions
+for installing the update. This works because an ABI update involves
+new packages. The  _apt-get_ command will install the updates for existing
+packages, but it will not install the new packages. While this method can
+be used to install the other updates, it is not recommended since
+there are presumably security patches needed for the kernel and they
+are not being installed in this case.
+
+==== Updating out-of-tree modules
+
+When a ABI update is installed, it will be necessary to update any,
+so-called, _out-of-tree_ modules that use the kernel ABI. This must be
+done _after_ rebooting with the new kernel installed.
+
+For a normal FSL10 installations, unless you have installed other
+out-of-tree modules, the only module that needs to be rebuilt is the
+GPIB driver (if it is installed).  You will need to recompile it (usually using _fsadapt_,
+        `Window 2`, `config_gpib` only) _after_ the initial reboot
+        and then (to keep these instructions simple) reboot _again_.
+
+If you have installed other out-of-tree modules (e.g., you use a
+special driver for some of your NICs), you will need to update them
+appropriately _after_ the initial reboot and then (to keep these
+        instructions simple) reboot _again_.
+
+===  Recovery from a failed update
+
+If an update fails, e.g., an updated kernel fails to boot or another problem is discovered,
+you can recover as described in FSL10 RAID document
+<<raid.adoc#_recoverable_testing,Recoverable testing>>
+section, if you were following that method, or from a shelf disk
+according to the FSL10 RAID document <<raid.adoc#_recover_from_a_shelf_disk,Recover from
+a shelf disk>> section if not and you have a good shelf disk.
+
+==== Additional recovery option for a failed ABI kernel update
+
+For a ABI update that has failed, it is also possible to try to use
+the previous kernel on the current system. For a single boot, use the
+`Advanced` option in the _grub_ menu at boot and then select the
+previous kernel. You can change back permanently to the previous
+kernel by purging the new kernel and its headers. To do this, use:
+
+    dpkg -l|grep linux-image
+    dpkg -l|grep linux-headers
+
+to determine the ABI version to be removed. For example, for the
+first command above, you may get:
+
+    linux-image-4.9.0-11-amd64
+    linux-image-4.9.0-12-amd64
+
+The package with _12_ would be the later version that should be purged:
+
+    apt-get purge linux-image-4.9.0-12-amd64
+
+Likewise with the linux-headers. For example, for the _12_ ABI
+version, there will be two packages you should purge:
+
+    linux-headers-4.9.0-12-amd64
+    linux-headers-4.9.0-12-common
+
+=== Manually checking for updates
+
+If you do not use the weekly _cron_ job to check for updates, or if
+you want to make sure you have the very latest updates when you
+install them, you can run the distributed copy of the weekly update
+script manually to check for updates:
+
+    /root/fsl10/etc_cron.weekly_apt-show-upgradeable
+
+If there is no output, there are no updates to install.
+
+If there is output, there are updates to install.
+You can install them by following the installation procedure in
+sub-section <<Installing updates (Upgrading)>> above, except you will use the
+instructions from the output of the script above instead of from the
+weekly _cron_ job (the outputs should be equivalent for the same set of
+        updates). Additionally, please read the following *NOTE*.
+
+NOTE: If the weekly _cron_ job has not been installed, you may not get a
+    display of NEWS items and a chance to abort when you install the updates. You
+    can use the method below with the `--which=news` parameter to
+    check for NEWS before installing an update.
+
+Any NEWS items will be included in the script output along with the
+packages to be updated. If you would like to see any NEWS items more
+distinctly after the previous command and before installing the
+updates, you can run the script again using the `--which=news` option:
+
+    /root/fsl10/etc_cron.weekly_apt-show-upgradeable --which=news
+
+If there are updates available and no NEWS items, you will only get
+the installation instructions.
+
+You can use this second form of running the script to check for
+updates initially, if you do not need to review which updates are
+available (you will still get warnings about kernel updates). As
+usual, you will see no output at all if there are no updates
+available.
+
+=== End of security updates
+
+When support for _stretch_ ends, currently expected in June 2022,
+there will be no more security updates.  At that time, the existing
+packages will be migrated to the Debian archive site. This will be
+visible in the output from the weekly _cron_ job script as errors that
+the packages files can't be found. Two steps are needed at that time:
+
+. If you have been using the weekly _cron_ job, it should be deleted:
++
+    rm /etc/cron.weekly/apt-show-upgradeable
++
+(you may need to answer `*y*` to confirm)
+
+. Change the _/etc/apt/sources.list_ file to point to the archive
+site. Although there will be no more security updates, this will enable
+downloading of additional packages if they are needed. The new lines that
+should replace the corresponding lines are:
++
+   deb http://archive.debian.org/debian/ stretch main contrib non-free
+   deb http://archive.debian.org/debian-security stretch/updates main contrib non-free
+   deb http://archive.debian.org/debian-volatile stretch/volatile main contrib non-free
++
+And if you are using `deb-src` lines:
++
+   deb-src http://archive.debian.org/debian/ stretch main contrib non-free
+   deb-src http://archive.debian.org/debian-security stretch/updates main contrib non-free
+   deb-src http://archive.debian.org/debian-volatile stretch/volatile main contrib non-free
++
+Otherwise the `deb-src` lines can be commented out (with a leading `#`).
++
+In addition, if you want to install packages from more recent
+distributions that have been backported to _stretch_ you can add:
++
+  deb http://archive.debian.org/debian-backports stretch-backports main contrib non-free
++
+However, the "`backports`" are not normally needed.
++
+Lastly, update the index files:
++
+    apt-get update
++
+This may generate an error about a `Release` file having expired, but that is benign.
+
+[appendix]
+
+== Rescue mode
+
+Rescue mode is useful for repairing some problems that prevent booting
+and/or logging in.
+
+NOTE: If your computer's _setup_ utility is locked with a password, you
+may need that password to select booting from your installation media.
+
+NOTE: You should provide suitable values for your system when a
+specific value is required. Values that agree with the FSL10 install
+described in this document (or reasonable defaults) are shown in parentheses.
+
+. Boot from installation media
+. Select `Advanced options ...`
+. Select `... Rescue mode`
++
+
+[NOTE]
+====
+
+You could instead add parameters to the boot line (by entering kbd:[e] for UEFI or
+kbd:[Tab] for BIOS on the `... Rescue mode` line instead), following the
+directions in the <<Set boot options and boot installer>> section above.
+This is not necessary nor usually helpful, but if you use this approach the
+most useful parameters are probably `netcfg/disable_dhcp=true` and/or
+`time/zone=UTC`. Use of added parameters will change the dialogue
+below.
+
+====
+
+. Select Language (`English`)
+. Select Location (`United States`)
+. Select Keymap (`American English`)
+. Network configuration
++
+
+If no network is currently available (or you know that you do not need it
+for the rescue), simply press kbd:[Enter] when DHCP autoconfiguration starts and
+press kbd:[Enter] again for the resulting `Network autoconfiguration failed`
+message. Thereafter select `Do not configure the network at this time` and
+enter in the machine's hostname when prompted before continuing below.
+
++
+
+If the DHCP autoconfiguration succeeds before you can stop it, you may
+as well confirm the hostname and domainname and continue with the
+network anyway, since you never know when it might prove useful.
+(However, if you want to make sure you don't use the network, you can
+ select `Go Back` and press kbd:[Enter] for the resulting `Network
+ autoconfiguration failed` message.  Thereafter select `Do not
+ configure the network at this time` and enter in the machine's
+ hostname when prompted before continuing below.)
+
+
++
+
+Otherwise if the DHCP autoconfiguration fails and you want to use the
+network, press kbd:[Enter] for the resulting `Network autoconfiguration
+failed` message. You can then select the appropriate option, most
+likely `Configure network manually` and give appropriate responses to the
+prompts, ultimately continuing below.
+
+. Select time zone (`Eastern`)
++
+
+NOTE: The selected time zone will have no effect on the timestamps
+stored on the disk for any changes you may make, but will affect the displayed times you see.
+
+. Select `Assemble RAID array`
+. Press kbd:[Space] on `Automatic`
++
+Press kbd:[Enter] to continue
+
+. Select your root file system (_/dev/vg0/root_)
+. Select `Yes` to mount separate _/boot_ partition (_/boot_), unless it is corrupt
+. Select `Yes` to mount separate _/boot/efi_ partition (_/boot/efi_), unless it is corrupt
+. Select _Execute a shell in /dev/vg0/root_ (or whatever your root file system is)
+. Select `Continue` to enter rescue mode
+. Use whatever commands are needed for your repair
++
+
+[NOTE]
+====
+If you need to use the network, DNS does not appear to work by
+default in recovery mode. Use of explicit IP addresses does work. If
+you need to use DNS, you can make it functional by deleting the symbolic
+link _/etc/resolv.conf_ and creating it as a normal file with the
+nameserver information you want, e.g.:
+
+    rm /etc/resolv.conf
+    cat >>/etc/resolv.conf <<EOF
+    nameserver 8.8.8.8
+    EOF
+====
+
+. Use the _exit_ command to exit when done
+. Select `Reboot the system`
+. "`Bob's your uncle`" (i.e., you are done!)

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.5.1 - December 2021
+Version 1.6.0 - December 2021
 
 :sectnums:
 :experimental:
@@ -636,6 +636,88 @@ terminated early with kbd:[Ctrl-C], without affecting the recovery.
 If you abort the progress indicator, you can check the progress with _mdstat_. The
 system can be used normally while it recovering, but it may be a
 little slow.
+
+=== raid-events
+
+The _mdmonitor_ service can be configured to use the _raid-events_
+script to send email reports on RAID rebuilds and checks. This is most
+useful for getting reports for the start and end of a RAID build
+triggered by _refresh_secondary_. The script will also report on the
+start and end of any other RAID rebuilds, including those triggered by
+the _recover_raid_ script. Checks are triggered periodically to verify
+the integrity of the RAIDs.
+
+The emails are sent to _root_, then typically redirected to _oper_,`
+and then forwarded to off-system accounts that may have their email
+read more frequently. There are four different possible subject lines
+used in the emails:
+
+* `Rebuild Running on _device_`
+
++
+
+NOTE: Sometimes for a rebuild started by _refresh_secondary_, this
+message may be sent about 20 minutes after the rebuild has started.
+The cause of this is not entirely understood, but the message is
+eventually sent.
+
+* `Rebuild Ended _state_ on _device_`
+
+* `Check Running on _device_`
+
+* `Check Ended _state_ on _device_`
+
+where:
+
+* `_device_` is the RAID device, e.g., _/dev/md/0_
+
+* `_state_` is `OKAY` if the final state was not degraded; `DEGRADED`,
+if it was degraded.
+
+The body of each email is the output of the _mdstat_ script at the
+time the message was sent.
+
+==== Checking
+
+The _checking_ process is triggered by _/etc/cron.d/mdadm_ on
+the first Sunday of each month. It uses the
+_/usr/share/mdadm/checkarray_ script and takes a similar amount of time
+as a rebuild of the RAID triggered by _refresh_secondary_.
+
+==== Installation
+
+To install the script, use the following commands as _root_:
+
+```
+cd /usr/local/sbin
+cp ~/fsl10/RAID/raid-events .
+chmod u+x raid-events
+cat <<EOF >>/etc/mdadm/mdadm.conf
+
+PROGRAM /usr/local/sbin/raid-events
+EOF
+```
+
+And then reboot.
+
+==== Disabling checking
+
+If the checking process causes performance problems at inconvenient
+times, there are at least three options for dealing with it:
+
+* Disable the `AUTOCHECK` option in _/etc/default/mdadm_
+
++
+
+This is suitable if the RAID is rebuilt monthly using
+_refresh_secondary_. In this case, the check is superfluous.
+
+* Change the time at which it runs as configured in
+_/etc/cron.d/mdadm_
+
+* Cancel a running check, with:
+
+  /usr/share/mdadm/checkarray --cancel --all
 
 === refresh_spare_usr2
 

--- a/raid.adoc
+++ b/raid.adoc
@@ -20,7 +20,7 @@
 
 = RAID Notes for FSL 10
 J.F.H. Quick, W.E. Himwich, and D.E. Horsley
-Version 1.6.0 - December 2021
+Version 1.6.0 - January 2022
 
 :sectnums:
 :experimental:
@@ -677,14 +677,14 @@ if it was degraded.
 The body of each email is the output of the _mdstat_ script at the
 time the message was sent.
 
-==== Checking
+==== Checks
 
 The _checking_ process is triggered by _/etc/cron.d/mdadm_ on
 the first Sunday of each month. It uses the
 _/usr/share/mdadm/checkarray_ script and takes a similar amount of time
 as a rebuild of the RAID triggered by _refresh_secondary_.
 
-==== Installation
+==== Installing raid-events
 
 To install the script, use the following commands as _root_:
 


### PR DESCRIPTION
Here is a suggestion for a means to send emails to report when RAID rebuilds start and end. It has been tested on four systems. It appears to handle both RAID rebuilds and RAID checks.

Sometimes for a rebuild started by _refresh_secondary_, the message for the start may be sent about 20 minutes late, but it is sent eventually.